### PR TITLE
workflow to support onnx export through stages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+*.pt
+*.ckpt
+*.onnx
+__pycache__
+.cache
+.ipynb_checkpoints
+*.log
+gen_rollout/
+
+.env
+.venv
+
+.vscode

--- a/evaluate/rollout_onnx.py
+++ b/evaluate/rollout_onnx.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+import imageio
+import numpy as np
+import onnxruntime as ort
+import torch
+import onnx
+from PIL import Image  # noqa: F401  # kept in case downstream uses it
+from omegaconf import ListConfig, OmegaConf
+from pytorch_lightning import seed_everything
+from torchvision.utils import save_image
+from tqdm import tqdm
+
+# Ensure project root (one level up from this file) is in sys.path
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(PROJECT_ROOT))
+
+try:
+    from external.orbis.util import instantiate_from_config  # noqa: E402
+except ModuleNotFoundError:
+    from util import instantiate_from_config  # noqa: E402
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] [%(levelname)s] %(message)s",
+)
+
+
+def str2bool(v: str | bool) -> bool:
+    if isinstance(v, bool):
+        return v
+    val = v.lower()
+    if val in {"yes", "true", "t", "y", "1"}:
+        return True
+    if val in {"no", "false", "f", "n", "0"}:
+        return False
+    raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
+def get_ckpt_epoch_step(ckpt_path: Path) -> Tuple[int, int]:
+    """Return (epoch, global_step) from a PyTorch Lightning checkpoint."""
+    ckpt = torch.load(str(ckpt_path), map_location="cpu")
+    return int(ckpt.get("epoch", 0)), int(ckpt.get("global_step", 0))
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def to_uint8_image(t: torch.Tensor) -> np.ndarray:
+    if t.dim() != 3:
+        raise ValueError(f"Expected CHW tensor, got shape {tuple(t.shape)}")
+    if t.min().item() < 0.0:
+        t = (t + 1.0) / 2.0
+    t = t.clamp(0, 1)
+    t = t.detach().float().cpu()
+    t = (t * 255.0).round().to(torch.uint8).permute(1, 2, 0).contiguous()
+    return t.numpy()
+
+
+def gif_from_frames(frames: List[torch.Tensor], fps: int = 7) -> List[np.ndarray]:
+    return [to_uint8_image(frm) for frm in frames]
+
+
+def length_of(loader: Iterable) -> Optional[int]:
+    try:
+        return len(loader)  # type: ignore[arg-type]
+    except TypeError:
+        return None
+
+
+def resolve_input_hw(input_size: object) -> Tuple[int, int]:
+    if isinstance(input_size, (list, tuple, ListConfig)):
+        return int(input_size[0]), int(input_size[1])
+    size = int(input_size)
+    return size, size
+
+
+def build_ort_session(args: argparse.Namespace) -> ort.InferenceSession:
+    available_providers = ort.get_available_providers()
+    providers = ["CPUExecutionProvider"]
+    if args.device.startswith("cuda") and "CUDAExecutionProvider" in available_providers:
+        providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+    session_options = ort.SessionOptions()
+    if not args.enable_ort_optimizations:
+        session_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+
+    session = ort.InferenceSession(
+        str(args.onnx),
+        sess_options=session_options,
+        providers=providers,
+    )
+    logger.info(f"ONNX Runtime providers: {session.get_providers()}")
+    logger.info(f"ORT graph optimizations enabled: {args.enable_ort_optimizations}")
+    return session
+
+
+def ensure_tokenizer_env(config_path: Path, exp_dir: Path) -> None:
+    config_text = config_path.read_text(encoding="utf-8")
+    if "$TK_WORK_DIR" not in config_text:
+        return
+    if os.getenv("TK_WORK_DIR"):
+        return
+
+    candidate_roots = [exp_dir.parent, exp_dir, PROJECT_ROOT.parent.parent / "checkpoints"]
+    for candidate_root in candidate_roots:
+        tokenizer_dir = candidate_root / "tokenizer_288x512"
+        if tokenizer_dir.exists():
+            os.environ["TK_WORK_DIR"] = str(candidate_root)
+            logger.info(f"Set TK_WORK_DIR to: {candidate_root}")
+            return
+
+    logger.warning("Config references $TK_WORK_DIR but no tokenizer_288x512 folder was found to infer it.")
+
+
+def export_vit_to_onnx(
+    *,
+    model: torch.nn.Module,
+    onnx_path: Path,
+    use_ema: bool,
+    do_constant_folding: bool,
+) -> None:
+    class VitWrapper(torch.nn.Module):
+        def __init__(self, vit: torch.nn.Module):
+            super().__init__()
+            self.vit = vit
+
+        def forward(self, target_t: torch.Tensor, context: torch.Tensor, t: torch.Tensor, frame_rate: torch.Tensor) -> torch.Tensor:
+            return self.vit(target_t, context, t, frame_rate=frame_rate)
+
+    if use_ema and hasattr(model, "ema_vit"):
+        logger.info("Applying EMA weights before ONNX export")
+        ema_params = dict(model.ema_vit.named_parameters())
+        for name, param in model.vit.named_parameters():
+            if name in ema_params:
+                param.data.copy_(ema_params[name].data)
+
+    input_h, input_w = resolve_input_hw(model.vit.input_size)
+
+    dummy_target_t = torch.randn(1, 1, model.vit.in_channels, input_h, input_w, device=next(model.parameters()).device)
+    dummy_context_frames = max(1, int(getattr(model.vit, "max_num_frames", 2)) - 1)
+    dummy_context = torch.randn(
+        1,
+        dummy_context_frames,
+        model.vit.in_channels,
+        input_h,
+        input_w,
+        device=dummy_target_t.device,
+    )
+    dummy_t = torch.rand(1, device=dummy_target_t.device)
+    dummy_frame_rate = torch.ones(1, device=dummy_target_t.device)
+
+    onnx_path.parent.mkdir(parents=True, exist_ok=True)
+    wrapper = VitWrapper(model.vit).eval()
+    torch.onnx.export(
+        wrapper,
+        (dummy_target_t, dummy_context, dummy_t, dummy_frame_rate),
+        str(onnx_path),
+        opset_version=17,
+        do_constant_folding=do_constant_folding,
+        input_names=["target_t", "context", "t", "frame_rate"],
+        output_names=["output"],
+        dynamic_axes={
+            "target_t": {0: "batch"},
+            "context": {0: "batch", 1: "context_frames"},
+            "t": {0: "batch"},
+            "frame_rate": {0: "batch"},
+            "output": {0: "batch"},
+        },
+        verbose=False,
+    )
+    onnx.checker.check_model(str(onnx_path))
+    logger.info(f"Exported ONNX model to: {onnx_path}")
+
+
+def _build_ort_inputs(
+    session: ort.InferenceSession,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> dict[str, np.ndarray]:
+    named_inputs = {
+        "target_t": np.ascontiguousarray(target_t.detach().float().cpu().numpy()),
+        "context": np.ascontiguousarray(context.detach().float().cpu().numpy()),
+        "t": np.ascontiguousarray(t.detach().float().cpu().numpy()),
+        "frame_rate": np.ascontiguousarray(frame_rate.detach().float().cpu().numpy()),
+    }
+    session_input_names = [session_input.name for session_input in session.get_inputs()]
+    if all(name in named_inputs for name in session_input_names):
+        return {name: named_inputs[name] for name in session_input_names}
+
+    ordered_arrays = [named_inputs["target_t"], named_inputs["context"], named_inputs["t"], named_inputs["frame_rate"]]
+    return {
+        session_input.name: ordered_arrays[index]
+        for index, session_input in enumerate(session.get_inputs())
+    }
+
+
+def vit_forward_onnx(
+    session: ort.InferenceSession,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> torch.Tensor:
+    onnx_inputs = _build_ort_inputs(session, target_t, context, t, frame_rate)
+    output = session.run(None, onnx_inputs)[0]
+    return torch.from_numpy(output).to(device=target_t.device, dtype=target_t.dtype)
+
+
+@torch.no_grad()
+def sample_onnx(
+    *,
+    model: torch.nn.Module,
+    ort_session: ort.InferenceSession,
+    images: torch.Tensor,
+    eta: float,
+    nfe: int,
+    num_samples: int,
+    frame_rate: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    device = next(model.parameters()).device
+    context = images.clone()
+
+    if frame_rate is None:
+        frame_rate = torch.full((num_samples,), 5.0, device=device, dtype=torch.float32)
+    else:
+        frame_rate = frame_rate.to(device=device, dtype=torch.float32)
+
+    input_h, input_w = resolve_input_hw(model.vit.input_size)
+
+    target_t = torch.randn(num_samples, 1, model.vit.in_channels, input_h, input_w, device=device)
+    t_steps = torch.linspace(1, 0, nfe + 1, device=device)
+
+    for i in range(nfe):
+        t = t_steps[i].repeat(target_t.shape[0])
+        neg_v = vit_forward_onnx(
+            ort_session,
+            target_t,
+            context,
+            t=t * model.timescale,
+            frame_rate=frame_rate,
+        )
+        dt = t_steps[i] - t_steps[i + 1]
+        dw = torch.randn_like(target_t) * torch.sqrt(dt)
+        diffusion = dt
+        target_t = target_t + neg_v * dt + eta * torch.sqrt(2 * diffusion) * dw
+
+    last_frame = target_t.clone()
+    images_out = model.decode_frames(last_frame)
+    return target_t.squeeze(1), images_out
+
+
+@torch.no_grad()
+def roll_out_onnx(
+    *,
+    model: torch.nn.Module,
+    ort_session: ort.InferenceSession,
+    x_0: torch.Tensor,
+    num_gen_frames: int,
+    eta: float,
+    nfe: int,
+    num_samples: int,
+    frame_rate: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_c = model.encode_frames(x_0)
+    x_all = x_c.clone()
+    samples = []
+
+    for _ in tqdm(range(num_gen_frames), desc="Rolling out frames", leave=False):
+        x_last, sample = sample_onnx(
+            model=model,
+            ort_session=ort_session,
+            images=x_c,
+            eta=eta,
+            nfe=nfe,
+            num_samples=num_samples,
+            frame_rate=frame_rate,
+        )
+        x_all = torch.cat([x_all, x_last.unsqueeze(1)], dim=1)
+        x_c = torch.cat([x_c[:, 1:], x_last.unsqueeze(1)], dim=1)
+        samples.append(sample)
+
+    return x_all, torch.cat(samples, dim=1)
+
+
+@torch.inference_mode()
+def generate_images(args: argparse.Namespace, unknown_args: List[str]) -> None:
+    frames_dir = Path(args.frames_dir)
+    if frames_dir.exists():
+        logger.warning(
+            "Output folder exists. New images will be added to the same folder. "
+            "Delete it if you want to start from scratch."
+        )
+    else:
+        ensure_dir(frames_dir)
+
+    torch.backends.cudnn.deterministic = True
+    seed_everything(args.seed)
+
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+    logger.info(f"Using device: {device}")
+
+    ensure_tokenizer_env(Path(args.config), Path(args.exp_dir))
+
+    base_cfg = OmegaConf.load(args.config)
+    cfg = OmegaConf.merge(base_cfg, OmegaConf.from_dotlist(unknown_args))
+
+    model = instantiate_from_config(cfg.model)
+    state = torch.load(str(args.ckpt), map_location="cpu")["state_dict"]
+    model.load_state_dict(state, strict=True)
+    model = model.to(device).eval()
+
+    onnx_path = Path(args.onnx)
+    if not onnx_path.exists():
+        logger.warning(f"ONNX model not found at {onnx_path}. Exporting it now.")
+        export_vit_to_onnx(
+            model=model,
+            onnx_path=onnx_path,
+            use_ema=args.evaluate_ema,
+            do_constant_folding=args.enable_constant_folding,
+        )
+
+    ort_session = build_ort_session(args)
+    if args.evaluate_ema:
+        logger.info("Using weights baked into the ONNX model; evaluate_ema does not switch weights at runtime.")
+
+    if args.val_config is not None:
+        data_cfg = OmegaConf.merge(
+            OmegaConf.load(args.val_config), OmegaConf.from_dotlist(unknown_args)
+        )
+    else:
+        data_cfg = cfg
+
+    num_condition_frames = None
+    if args.save_real:
+        num_condition_frames = data_cfg.data.params.validation.params.num_frames - 1
+        num_frames_total = num_condition_frames + args.num_gen_frames
+        data_cfg.data.params.validation.params.num_frames = num_frames_total
+
+    if hasattr(data_cfg.data.params, "train"):
+        del data_cfg.data.params.train
+
+    data_module = instantiate_from_config(data_cfg.data)
+    data_module.prepare_data()
+    data_module.setup()
+    val_loader = data_module.val_dataloader()
+
+    logger.info(f"Saving outputs to: {args.frames_dir}")
+    total_batches = length_of(val_loader)
+    pbar = tqdm(total=total_batches, desc="Generating", dynamic_ncols=True)
+
+    sample_idx = 0
+    for batch in val_loader:
+        if args.num_videos is not None and sample_idx >= args.num_videos:
+            break
+
+        if isinstance(batch, dict):
+            x = batch["images"].to(device, non_blocking=True)
+            frame_rate = batch.get("frame_rate")
+            if frame_rate is not None:
+                frame_rate = frame_rate.to(device, non_blocking=True)
+        else:
+            x = batch.to(device, non_blocking=True)
+            frame_rate = None
+
+        cond_x = x[:, :num_condition_frames]
+
+        with torch.no_grad():
+            _, gen_frames = roll_out_onnx(
+                model=model,
+                ort_session=ort_session,
+                x_0=cond_x,
+                num_gen_frames=args.num_gen_frames,
+                eta=args.eta,
+                nfe=args.num_steps,
+                num_samples=cond_x.size(0),
+                frame_rate=frame_rate,
+            )
+
+        for b in range(x.size(0)):
+            if args.num_videos is not None and sample_idx >= args.num_videos:
+                break
+
+            seq_name = f"sequence_{sample_idx:04d}"
+            fake_dir = frames_dir / "fake_images" / seq_name
+            gif_dir = frames_dir / "gen_gifs"
+            ensure_dir(fake_dir)
+            ensure_dir(gif_dir)
+
+            seq_frames = gen_frames[b]
+            time_steps = seq_frames.shape[0]
+
+            for f_idx in range(time_steps):
+                frame = (seq_frames[f_idx] + 1.0) / 2.0
+                save_image(frame, fake_dir / f"frame_{f_idx:04d}.jpg")
+
+            gif_frames = gif_from_frames([seq_frames[f] for f in range(time_steps)], fps=7)
+            imageio.mimsave(gif_dir / f"{seq_name}.gif", gif_frames, fps=7, loop=0)
+
+            if args.save_real:
+                real_dir = frames_dir / "real_images" / seq_name
+                ensure_dir(real_dir)
+                for f_idx in range(x.shape[1]):
+                    real_frame = (x[b, f_idx] + 1.0) / 2.0
+                    save_image(real_frame, real_dir / f"frame_{f_idx:04d}.jpg")
+
+            sample_idx += 1
+
+        if total_batches is not None:
+            pbar.update(1)
+        else:
+            pbar.set_postfix_str(f"samples={sample_idx}")
+
+    pbar.close()
+    if device.type == "cuda":
+        max_mem_gb = torch.cuda.max_memory_allocated() / 1024**3
+        logger.info(f"Max CUDA memory: {max_mem_gb:.02f} GB")
+
+
+def build_output_dir(
+    exp_dir: Path,
+    frames_dir_arg: Optional[str],
+    ckpt_path: Path,
+    val_config: Optional[str],
+    num_steps: int,
+) -> Path:
+    if frames_dir_arg is not None:
+        return (exp_dir / frames_dir_arg).resolve()
+    epoch, global_step = get_ckpt_epoch_step(ckpt_path)
+    data_tag = Path(val_config).stem if val_config is not None else "default_data"
+    rel = Path("gen_rollout") / data_tag / f"ep{epoch}iter{global_step}_{num_steps}steps"
+    return (exp_dir / rel).resolve()
+
+
+def parse_args(argv: Optional[List[str]] = None) -> Tuple[argparse.Namespace, List[str]]:
+    parser = argparse.ArgumentParser(
+        description="Generate rollouts (frames + GIFs) from an exported ONNX model."
+    )
+    parser.add_argument("--exp_dir", type=str, required=True, help="Experiment directory (contains config and checkpoints).")
+    parser.add_argument("--ckpt", type=str, default="checkpoints/last.ckpt", help="Checkpoint path, relative to exp_dir.")
+    parser.add_argument("--onnx", type=str, default="onnx/last_enhanced.onnx", help="ONNX model path, relative to exp_dir.")
+    parser.add_argument("--config", type=str, default="config.yaml", help="Config path, relative to exp_dir.")
+    parser.add_argument("--val_config", type=str, default=None, help="Optional validation data config path (absolute or relative to exp_dir).")
+    parser.add_argument("--num_gen_frames", type=int, default=1, help="Number of frames to generate (roll-out length).")
+    parser.add_argument("--frames_dir", type=str, default=None, help="Output directory for frames/GIFs (relative to exp_dir if relative).")
+    parser.add_argument("--save_real", type=str2bool, default=False, help="Also save ground-truth frames next to generated ones.")
+    parser.add_argument("--num_videos", type=int, default=None, help="Generate at most this many sequences (None = all).")
+    parser.add_argument("--seed", type=int, default=42, help="PRNG seed.")
+    parser.add_argument("--device", type=str, default="cuda", help='Device string (e.g., "cuda", "cuda:0", or "cpu").')
+    parser.add_argument("--num_steps", type=int, default=30, help="Sampler steps (passed to roll_out as NFE).")
+    parser.add_argument("--eta", type=float, default=0.0, help="Stochasticity for sampling (passed to roll_out).")
+    parser.add_argument("--evaluate_ema", type=str2bool, default=True, help="Kept for CLI compatibility; ONNX uses the weights baked into the exported model.")
+    parser.add_argument("--enable_ort_optimizations", type=str2bool, default=False, help="Enable ONNX Runtime graph optimizations. Disabled by default for this model.")
+    parser.add_argument("--enable_constant_folding", type=str2bool, default=False, help="Enable constant folding during ONNX export when auto-exporting a missing model.")
+    args, unknown = parser.parse_known_args(argv)
+
+    exp_dir = Path(args.exp_dir).resolve()
+    ckpt = (exp_dir / args.ckpt).resolve()
+    onnx_path = (exp_dir / args.onnx).resolve() if not Path(args.onnx).is_absolute() else Path(args.onnx).resolve()
+    config = (exp_dir / args.config).resolve()
+    val_config = (
+        (exp_dir / args.val_config).resolve()
+        if args.val_config and not Path(args.val_config).is_absolute()
+        else (Path(args.val_config).resolve() if args.val_config else None)
+    )
+
+    if not exp_dir.exists():
+        raise FileNotFoundError(f"exp_dir not found: {exp_dir}")
+    if not ckpt.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {ckpt}")
+    if not config.exists():
+        raise FileNotFoundError(f"Config not found: {config}")
+    if val_config is not None and not val_config.exists():
+        raise FileNotFoundError(f"val_config not found: {val_config}")
+
+    frames_dir = build_output_dir(
+        exp_dir=exp_dir,
+        frames_dir_arg=args.frames_dir,
+        ckpt_path=ckpt,
+        val_config=str(val_config) if val_config is not None else None,
+        num_steps=args.num_steps,
+    )
+
+    args.exp_dir = str(exp_dir)
+    args.ckpt = str(ckpt)
+    args.onnx = str(onnx_path)
+    args.config = str(config)
+    args.val_config = str(val_config) if val_config is not None else None
+    args.frames_dir = str(frames_dir)
+    return args, unknown
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args, unknown = parse_args(argv)
+    generate_images(args, unknown)
+
+
+if __name__ == "__main__":
+    main()

--- a/evaluate/rollout_tensorrt.py
+++ b/evaluate/rollout_tensorrt.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import imageio
+import torch
+from omegaconf import OmegaConf
+from pytorch_lightning import seed_everything
+from torchvision.utils import save_image
+from tqdm import tqdm
+
+from rollout_onnx import (
+    build_output_dir,
+    ensure_dir,
+    ensure_tokenizer_env,
+    export_vit_to_onnx,
+    get_ckpt_epoch_step,
+    gif_from_frames,
+    length_of,
+    logger,
+    resolve_input_hw,
+    str2bool,
+)
+
+
+try:
+    import tensorrt as trt
+except ModuleNotFoundError:
+    trt = None
+
+
+# Ensure project root (one level up from this file) is in sys.path
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+try:
+    from external.orbis.util import instantiate_from_config  # noqa: E402
+except ModuleNotFoundError:
+    from util import instantiate_from_config  # noqa: E402
+
+
+def _require_tensorrt() -> None:
+    if trt is None:
+        raise ModuleNotFoundError(
+            "TensorRT Python bindings are not installed in the active environment. "
+            "Install TensorRT and ensure `import tensorrt` works before using rollout_tensorrt.py."
+        )
+
+
+def build_engine_from_onnx(
+    *,
+    onnx_path: Path,
+    engine_path: Path,
+    input_hw: Tuple[int, int],
+    in_channels: int,
+    max_context_frames: int,
+    opt_batch_size: int,
+    max_batch_size: int,
+    workspace_gb: float,
+    enable_fp16: bool,
+) -> None:
+    _require_tensorrt()
+
+    logger_trt = trt.Logger(trt.Logger.INFO)
+    builder = trt.Builder(logger_trt)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+    parser = trt.OnnxParser(network, logger_trt)
+
+    onnx_bytes = onnx_path.read_bytes()
+    if not parser.parse(onnx_bytes):
+        errors = [parser.get_error(index).desc() for index in range(parser.num_errors)]
+        raise RuntimeError("TensorRT failed to parse ONNX:\n" + "\n".join(errors))
+
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, int(workspace_gb * (1024**3)))
+    if enable_fp16 and builder.platform_has_fast_fp16:
+        config.set_flag(trt.BuilderFlag.FP16)
+
+    input_h, input_w = input_hw
+    max_context_frames = max(1, int(max_context_frames))
+    opt_batch_size = max(1, int(opt_batch_size))
+    max_batch_size = max(opt_batch_size, int(max_batch_size))
+
+    profile = builder.create_optimization_profile()
+    profile.set_shape(
+        "target_t",
+        min=(1, 1, in_channels, input_h, input_w),
+        opt=(opt_batch_size, 1, in_channels, input_h, input_w),
+        max=(max_batch_size, 1, in_channels, input_h, input_w),
+    )
+    profile.set_shape(
+        "context",
+        min=(1, 1, in_channels, input_h, input_w),
+        opt=(opt_batch_size, max_context_frames, in_channels, input_h, input_w),
+        max=(max_batch_size, max_context_frames, in_channels, input_h, input_w),
+    )
+    profile.set_shape("t", min=(1,), opt=(opt_batch_size,), max=(max_batch_size,))
+    profile.set_shape("frame_rate", min=(1,), opt=(opt_batch_size,), max=(max_batch_size,))
+    config.add_optimization_profile(profile)
+
+    serialized_engine = builder.build_serialized_network(network, config)
+    if serialized_engine is None:
+        raise RuntimeError("TensorRT failed to build a serialized engine")
+
+    engine_path.parent.mkdir(parents=True, exist_ok=True)
+    engine_path.write_bytes(bytes(serialized_engine))
+    logger.info(f"Exported TensorRT engine to: {engine_path}")
+
+
+class TensorRTRunner:
+    def __init__(self, engine_path: Path):
+        _require_tensorrt()
+        runtime_logger = trt.Logger(trt.Logger.INFO)
+        runtime = trt.Runtime(runtime_logger)
+        self._engine = runtime.deserialize_cuda_engine(engine_path.read_bytes())
+        if self._engine is None:
+            raise RuntimeError(f"Failed to deserialize TensorRT engine: {engine_path}")
+        self._context = self._engine.create_execution_context()
+        if self._context is None:
+            raise RuntimeError("Failed to create TensorRT execution context")
+        self._input_names = [
+            self._engine.get_tensor_name(index)
+            for index in range(self._engine.num_io_tensors)
+            if self._engine.get_tensor_mode(self._engine.get_tensor_name(index)) == trt.TensorIOMode.INPUT
+        ]
+        self._output_names = [
+            self._engine.get_tensor_name(index)
+            for index in range(self._engine.num_io_tensors)
+            if self._engine.get_tensor_mode(self._engine.get_tensor_name(index)) == trt.TensorIOMode.OUTPUT
+        ]
+        if self._output_names != ["output"]:
+            logger.warning(f"Unexpected TensorRT output tensors: {self._output_names}")
+
+    def forward(
+        self,
+        target_t: torch.Tensor,
+        context: torch.Tensor,
+        t: torch.Tensor,
+        frame_rate: torch.Tensor,
+    ) -> torch.Tensor:
+        if target_t.device.type != "cuda":
+            raise ValueError("TensorRT inference requires CUDA tensors")
+
+        inputs = {
+            "target_t": target_t.contiguous().float(),
+            "context": context.contiguous().float(),
+            "t": t.contiguous().float(),
+            "frame_rate": frame_rate.contiguous().float(),
+        }
+        for name, tensor in inputs.items():
+            self._context.set_input_shape(name, tuple(int(dim) for dim in tensor.shape))
+
+        output_name = self._output_names[0]
+        output_shape = tuple(int(dim) for dim in self._context.get_tensor_shape(output_name))
+        output = torch.empty(output_shape, device=target_t.device, dtype=torch.float32)
+
+        for name, tensor in inputs.items():
+            self._context.set_tensor_address(name, int(tensor.data_ptr()))
+        self._context.set_tensor_address(output_name, int(output.data_ptr()))
+
+        stream = torch.cuda.current_stream(device=target_t.device)
+        success = self._context.execute_async_v3(stream.cuda_stream)
+        if not success:
+            raise RuntimeError("TensorRT execution failed")
+        return output.to(dtype=target_t.dtype)
+
+
+@torch.no_grad()
+def sample_tensorrt(
+    *,
+    model: torch.nn.Module,
+    runner: TensorRTRunner,
+    images: torch.Tensor,
+    eta: float,
+    nfe: int,
+    num_samples: int,
+    frame_rate: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    device = next(model.parameters()).device
+    context = images.clone()
+
+    if frame_rate is None:
+        frame_rate = torch.full((num_samples,), 5.0, device=device, dtype=torch.float32)
+    else:
+        frame_rate = frame_rate.to(device=device, dtype=torch.float32)
+
+    input_h, input_w = resolve_input_hw(model.vit.input_size)
+    target_t = torch.randn(num_samples, 1, model.vit.in_channels, input_h, input_w, device=device)
+    t_steps = torch.linspace(1, 0, nfe + 1, device=device)
+
+    for i in range(nfe):
+        t = t_steps[i].repeat(target_t.shape[0])
+        neg_v = runner.forward(
+            target_t,
+            context,
+            t=t * model.timescale,
+            frame_rate=frame_rate,
+        )
+        dt = t_steps[i] - t_steps[i + 1]
+        dw = torch.randn_like(target_t) * torch.sqrt(dt)
+        diffusion = dt
+        target_t = target_t + neg_v * dt + eta * torch.sqrt(2 * diffusion) * dw
+
+    last_frame = target_t.clone()
+    images_out = model.decode_frames(last_frame)
+    return target_t.squeeze(1), images_out
+
+
+@torch.no_grad()
+def roll_out_tensorrt(
+    *,
+    model: torch.nn.Module,
+    runner: TensorRTRunner,
+    x_0: torch.Tensor,
+    num_gen_frames: int,
+    eta: float,
+    nfe: int,
+    num_samples: int,
+    frame_rate: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_c = model.encode_frames(x_0)
+    x_all = x_c.clone()
+    samples = []
+
+    for _ in tqdm(range(num_gen_frames), desc="Rolling out frames", leave=False):
+        x_last, sample = sample_tensorrt(
+            model=model,
+            runner=runner,
+            images=x_c,
+            eta=eta,
+            nfe=nfe,
+            num_samples=num_samples,
+            frame_rate=frame_rate,
+        )
+        x_all = torch.cat([x_all, x_last.unsqueeze(1)], dim=1)
+        x_c = torch.cat([x_c[:, 1:], x_last.unsqueeze(1)], dim=1)
+        samples.append(sample)
+
+    return x_all, torch.cat(samples, dim=1)
+
+
+@torch.inference_mode()
+def generate_images(args: argparse.Namespace, unknown_args: List[str]) -> None:
+    _require_tensorrt()
+
+    frames_dir = Path(args.frames_dir)
+    if frames_dir.exists():
+        logger.warning(
+            "Output folder exists. New images will be added to the same folder. "
+            "Delete it if you want to start from scratch."
+        )
+    else:
+        ensure_dir(frames_dir)
+
+    torch.backends.cudnn.deterministic = True
+    seed_everything(args.seed)
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("TensorRT rollout requires CUDA, but torch.cuda.is_available() is False")
+
+    device = torch.device(args.device)
+    if device.type != "cuda":
+        raise ValueError("TensorRT rollout requires a CUDA device")
+    torch.cuda.set_device(device)
+    logger.info(f"Using device: {device}")
+
+    ensure_tokenizer_env(Path(args.config), Path(args.exp_dir))
+
+    base_cfg = OmegaConf.load(args.config)
+    cfg = OmegaConf.merge(base_cfg, OmegaConf.from_dotlist(unknown_args))
+
+    model = instantiate_from_config(cfg.model)
+    state = torch.load(str(args.ckpt), map_location="cpu")["state_dict"]
+    model.load_state_dict(state, strict=True)
+    model = model.to(device).eval()
+
+    onnx_path = Path(args.onnx)
+    if not onnx_path.exists():
+        logger.warning(f"ONNX model not found at {onnx_path}. Exporting it now as TensorRT build input.")
+        export_vit_to_onnx(
+            model=model,
+            onnx_path=onnx_path,
+            use_ema=args.evaluate_ema,
+            do_constant_folding=args.enable_constant_folding,
+        )
+
+    engine_path = Path(args.engine)
+    if not engine_path.exists():
+        logger.warning(f"TensorRT engine not found at {engine_path}. Building it now.")
+        input_hw = resolve_input_hw(model.vit.input_size)
+        max_context_frames = max(1, int(getattr(model.vit, "max_num_frames", 2)) - 1)
+        build_engine_from_onnx(
+            onnx_path=onnx_path,
+            engine_path=engine_path,
+            input_hw=input_hw,
+            in_channels=int(model.vit.in_channels),
+            max_context_frames=max_context_frames,
+            opt_batch_size=args.opt_batch_size,
+            max_batch_size=args.max_batch_size,
+            workspace_gb=args.trt_workspace_gb,
+            enable_fp16=args.enable_fp16,
+        )
+
+    runner = TensorRTRunner(engine_path)
+    if args.evaluate_ema:
+        logger.info("Using weights baked into the TensorRT engine; evaluate_ema does not switch weights at runtime.")
+
+    if args.val_config is not None:
+        data_cfg = OmegaConf.merge(
+            OmegaConf.load(args.val_config), OmegaConf.from_dotlist(unknown_args)
+        )
+    else:
+        data_cfg = cfg
+
+    num_condition_frames = None
+    if args.save_real:
+        num_condition_frames = data_cfg.data.params.validation.params.num_frames - 1
+        num_frames_total = num_condition_frames + args.num_gen_frames
+        data_cfg.data.params.validation.params.num_frames = num_frames_total
+
+    if hasattr(data_cfg.data.params, "train"):
+        del data_cfg.data.params.train
+
+    data_module = instantiate_from_config(data_cfg.data)
+    data_module.prepare_data()
+    data_module.setup()
+    val_loader = data_module.val_dataloader()
+
+    logger.info(f"Saving outputs to: {args.frames_dir}")
+    total_batches = length_of(val_loader)
+    pbar = tqdm(total=total_batches, desc="Generating", dynamic_ncols=True)
+
+    sample_idx = 0
+    for batch in val_loader:
+        if args.num_videos is not None and sample_idx >= args.num_videos:
+            break
+
+        if isinstance(batch, dict):
+            x = batch["images"].to(device, non_blocking=True)
+            frame_rate = batch.get("frame_rate")
+            if frame_rate is not None:
+                frame_rate = frame_rate.to(device, non_blocking=True)
+        else:
+            x = batch.to(device, non_blocking=True)
+            frame_rate = None
+
+        cond_x = x[:, :num_condition_frames]
+
+        _, gen_frames = roll_out_tensorrt(
+            model=model,
+            runner=runner,
+            x_0=cond_x,
+            num_gen_frames=args.num_gen_frames,
+            eta=args.eta,
+            nfe=args.num_steps,
+            num_samples=cond_x.size(0),
+            frame_rate=frame_rate,
+        )
+
+        for b in range(x.size(0)):
+            if args.num_videos is not None and sample_idx >= args.num_videos:
+                break
+
+            seq_name = f"sequence_{sample_idx:04d}"
+            fake_dir = frames_dir / "fake_images" / seq_name
+            gif_dir = frames_dir / "gen_gifs"
+            ensure_dir(fake_dir)
+            ensure_dir(gif_dir)
+
+            seq_frames = gen_frames[b]
+            time_steps = seq_frames.shape[0]
+
+            for f_idx in range(time_steps):
+                frame = (seq_frames[f_idx] + 1.0) / 2.0
+                save_image(frame, fake_dir / f"frame_{f_idx:04d}.jpg")
+
+            gif_frames = gif_from_frames([seq_frames[f] for f in range(time_steps)], fps=7)
+            imageio.mimsave(gif_dir / f"{seq_name}.gif", gif_frames, fps=7, loop=0)
+
+            if args.save_real:
+                real_dir = frames_dir / "real_images" / seq_name
+                ensure_dir(real_dir)
+                for f_idx in range(x.shape[1]):
+                    real_frame = (x[b, f_idx] + 1.0) / 2.0
+                    save_image(real_frame, real_dir / f"frame_{f_idx:04d}.jpg")
+
+            sample_idx += 1
+
+        if total_batches is not None:
+            pbar.update(1)
+        else:
+            pbar.set_postfix_str(f"samples={sample_idx}")
+
+    pbar.close()
+    max_mem_gb = torch.cuda.max_memory_allocated(device) / 1024**3
+    logger.info(f"Max CUDA memory: {max_mem_gb:.02f} GB")
+
+
+def parse_args(argv: Optional[List[str]] = None) -> Tuple[argparse.Namespace, List[str]]:
+    parser = argparse.ArgumentParser(
+        description="Generate rollouts (frames + GIFs) from a TensorRT engine."
+    )
+    parser.add_argument("--exp_dir", type=str, required=True, help="Experiment directory (contains config and checkpoints).")
+    parser.add_argument("--ckpt", type=str, default="checkpoints/last.ckpt", help="Checkpoint path, relative to exp_dir.")
+    parser.add_argument("--onnx", type=str, default="onnx/last_enhanced.onnx", help="ONNX path used as TensorRT build input, relative to exp_dir.")
+    parser.add_argument("--engine", type=str, default="tensorrt/last_enhanced_fp16.engine", help="TensorRT engine path, relative to exp_dir.")
+    parser.add_argument("--config", type=str, default="config.yaml", help="Config path, relative to exp_dir.")
+    parser.add_argument("--val_config", type=str, default=None, help="Optional validation data config path (absolute or relative to exp_dir).")
+    parser.add_argument("--num_gen_frames", type=int, default=1, help="Number of frames to generate (roll-out length).")
+    parser.add_argument("--frames_dir", type=str, default=None, help="Output directory for frames/GIFs (relative to exp_dir if relative).")
+    parser.add_argument("--save_real", type=str2bool, default=False, help="Also save ground-truth frames next to generated ones.")
+    parser.add_argument("--num_videos", type=int, default=None, help="Generate at most this many sequences (None = all).")
+    parser.add_argument("--seed", type=int, default=42, help="PRNG seed.")
+    parser.add_argument("--device", type=str, default="cuda:0", help='CUDA device string, for example "cuda:0".')
+    parser.add_argument("--num_steps", type=int, default=30, help="Sampler steps (passed to roll_out as NFE).")
+    parser.add_argument("--eta", type=float, default=0.0, help="Stochasticity for sampling (passed to roll_out).")
+    parser.add_argument("--evaluate_ema", type=str2bool, default=True, help="Kept for CLI compatibility; TensorRT uses the weights baked into the engine.")
+    parser.add_argument("--enable_constant_folding", type=str2bool, default=False, help="Enable constant folding during ONNX export when auto-exporting a missing model.")
+    parser.add_argument("--enable_fp16", type=str2bool, default=True, help="Enable FP16 TensorRT engine building when supported.")
+    parser.add_argument("--trt_workspace_gb", type=float, default=8.0, help="TensorRT workspace memory pool size in GB.")
+    parser.add_argument("--opt_batch_size", type=int, default=1, help="TensorRT optimization profile batch size.")
+    parser.add_argument("--max_batch_size", type=int, default=4, help="TensorRT optimization profile maximum batch size.")
+    args, unknown = parser.parse_known_args(argv)
+
+    exp_dir = Path(args.exp_dir).resolve()
+    ckpt = (exp_dir / args.ckpt).resolve()
+    onnx_path = (exp_dir / args.onnx).resolve() if not Path(args.onnx).is_absolute() else Path(args.onnx).resolve()
+    engine_path = (exp_dir / args.engine).resolve() if not Path(args.engine).is_absolute() else Path(args.engine).resolve()
+    config = (exp_dir / args.config).resolve()
+    val_config = (
+        (exp_dir / args.val_config).resolve()
+        if args.val_config and not Path(args.val_config).is_absolute()
+        else (Path(args.val_config).resolve() if args.val_config else None)
+    )
+
+    if not exp_dir.exists():
+        raise FileNotFoundError(f"exp_dir not found: {exp_dir}")
+    if not ckpt.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {ckpt}")
+    if not config.exists():
+        raise FileNotFoundError(f"Config not found: {config}")
+    if val_config is not None and not val_config.exists():
+        raise FileNotFoundError(f"val_config not found: {val_config}")
+
+    frames_dir = build_output_dir(
+        exp_dir=exp_dir,
+        frames_dir_arg=args.frames_dir,
+        ckpt_path=ckpt,
+        val_config=str(val_config) if val_config is not None else None,
+        num_steps=args.num_steps,
+    )
+
+    args.exp_dir = str(exp_dir)
+    args.ckpt = str(ckpt)
+    args.onnx = str(onnx_path)
+    args.engine = str(engine_path)
+    args.config = str(config)
+    args.val_config = str(val_config) if val_config is not None else None
+    args.frames_dir = str(frames_dir)
+    return args, unknown
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args, unknown = parse_args(argv)
+    generate_images(args, unknown)
+
+
+if __name__ == "__main__":
+    main()

--- a/export/__init__.py
+++ b/export/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+from .common import (
+    ArtifactResolver,
+    ModelLoader,
+    OnnxExporter,
+    OnnxSessionFactory,
+    ResolvedArtifactPaths,
+    VitOnnxExporter,
+    make_vit_inputs,
+    resolve_input_hw,
+)
+
+__all__ = [
+    "ArtifactResolver",
+    "ModelLoader",
+    "OnnxExporter",
+    "OnnxSessionFactory",
+    "ResolvedArtifactPaths",
+    "VitOnnxExporter",
+    "make_vit_inputs",
+    "resolve_input_hw",
+]

--- a/export/common.py
+++ b/export/common.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+from __future__ import annotations
+
+import argparse
+import os
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+from omegaconf import ListConfig, OmegaConf
+
+from util import instantiate_from_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_RUN_DIR = REPO_ROOT / "logs_wm" / "orbis_288x512"
+
+
+@dataclass(frozen=True)
+class ResolvedArtifactPaths:
+    config_path: Path
+    ckpt_path: Path
+    onnx_path: Path | None = None
+
+
+class ArtifactResolver:
+    def __init__(self, run_dir: Path = DEFAULT_RUN_DIR):
+        self.run_dir = run_dir
+        self.ckpt_dir = self.run_dir / "checkpoints"
+        self.onnx_dir = self.run_dir / "onnx"
+
+    def add_common_arguments(self, parser: argparse.ArgumentParser, *, include_onnx: bool = True) -> None:
+        parser.add_argument("--config-path", type=str, default=None)
+        parser.add_argument("--ckpt-path", type=str, default=None)
+        if include_onnx:
+            parser.add_argument("--onnx-path", type=str, default=None)
+
+    def expand_path(self, path_str: str) -> Path:
+        path = Path(path_str).expanduser()
+        if not path.is_absolute():
+            path = REPO_ROOT / path
+        return path
+
+    def latest_matching_file(self, directory: Path, pattern: str) -> Path:
+        matches = [path for path in directory.glob(pattern) if path.is_file()]
+        if not matches:
+            raise FileNotFoundError(f"No files matching '{pattern}' found in {directory}")
+        return max(matches, key=lambda path: path.stat().st_mtime)
+
+    def resolve_existing_file(self, path: Path, description: str) -> Path:
+        if not path.is_file():
+            raise FileNotFoundError(f"{description} does not exist: {path}")
+        return path
+
+    def default_config_path(self) -> Path:
+        return self.resolve_existing_file(self.run_dir / "config.yaml", "Config file")
+
+    def default_ckpt_path(self) -> Path:
+        return self.latest_matching_file(self.ckpt_dir, "*.ckpt")
+
+    def default_onnx_path(self) -> Path:
+        return self.latest_matching_file(self.onnx_dir, "*.onnx")
+
+    def resolve_from_args(self, args: argparse.Namespace, *, include_onnx: bool = True) -> ResolvedArtifactPaths:
+        config_path = self.resolve_existing_file(
+            self.expand_path(args.config_path) if args.config_path else self.default_config_path(),
+            "Config file",
+        )
+        ckpt_path = self.resolve_existing_file(
+            self.expand_path(args.ckpt_path) if args.ckpt_path else self.default_ckpt_path(),
+            "Checkpoint file",
+        )
+        onnx_path: Path | None = None
+        if include_onnx:
+            onnx_path = self.expand_path(args.onnx_path) if args.onnx_path else self.default_onnx_path()
+        return ResolvedArtifactPaths(config_path=config_path, ckpt_path=ckpt_path, onnx_path=onnx_path)
+
+
+class ModelLoader:
+    def __init__(self, *, strict: bool = False, use_ema: bool = True):
+        self.strict = strict
+        self.use_ema = use_ema
+
+    def load(self, config_path: Path, ckpt_path: Path) -> nn.Module:
+        self._ensure_tokenizer_env(config_path)
+        cfg = OmegaConf.load(config_path)
+        model = instantiate_from_config(cfg.model)
+        state = torch.load(ckpt_path, map_location="cpu", weights_only=False)["state_dict"]
+        model.load_state_dict(state, strict=self.strict)
+        model.eval()
+
+        if self.use_ema and hasattr(model, "ema_vit"):
+            ema_params = dict(model.ema_vit.named_parameters())
+            for name, param in model.vit.named_parameters():
+                if name in ema_params:
+                    param.data.copy_(ema_params[name].data)
+
+        return model
+
+    def _ensure_tokenizer_env(self, config_path: Path) -> None:
+        config_text = config_path.read_text(encoding="utf-8")
+        if "$TK_WORK_DIR" not in config_text:
+            return
+        if os.getenv("TK_WORK_DIR"):
+            return
+
+        candidate_roots = [
+            REPO_ROOT / "logs_tk",
+            REPO_ROOT,
+            config_path.parent,
+            config_path.parent.parent,
+        ]
+        for candidate_root in candidate_roots:
+            tokenizer_dir = candidate_root / "tokenizer_288x512"
+            if tokenizer_dir.exists():
+                os.environ["TK_WORK_DIR"] = str(candidate_root)
+                return
+
+
+class OnnxExporter:
+    def export(
+        self,
+        module: nn.Module,
+        inputs: Sequence[torch.Tensor] | tuple[torch.Tensor, ...],
+        onnx_path: Path,
+        *,
+        input_names: Sequence[str],
+        output_names: Sequence[str],
+        opset: int = 17,
+        do_constant_folding: bool = True,
+        dynamic_axes: Mapping[str, Mapping[int, str]] | None = None,
+    ) -> Path:
+        onnx_path.parent.mkdir(parents=True, exist_ok=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=UserWarning,
+                module=r"onnx(\..*)?",
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r"Constant folding - Only steps=1 can be constant folded.*",
+                category=UserWarning,
+                module=r"torch\.onnx(\..*)?",
+            )
+            torch.onnx.export(
+                module,
+                tuple(inputs),
+                str(onnx_path),
+                opset_version=opset,
+                do_constant_folding=do_constant_folding,
+                input_names=list(input_names),
+                output_names=list(output_names),
+                dynamic_axes=dynamic_axes,
+                verbose=False,
+            )
+            onnx.checker.check_model(str(onnx_path))
+        return onnx_path
+
+
+class OnnxSessionFactory:
+    def create_cpu_session(self, onnx_path: Path | str, *, disable_optimizations: bool = False) -> ort.InferenceSession:
+        session_options = ort.SessionOptions()
+        if disable_optimizations:
+            session_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        return ort.InferenceSession(
+            str(onnx_path),
+            sess_options=session_options,
+            providers=["CPUExecutionProvider"],
+        )
+
+
+class VitOnnxWrapper(nn.Module):
+    def __init__(self, vit: nn.Module):
+        super().__init__()
+        self.vit = vit
+
+    def forward(
+        self,
+        target_t: torch.Tensor,
+        context: torch.Tensor,
+        t: torch.Tensor,
+        frame_rate: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.vit(target_t, context, t, frame_rate=frame_rate)
+
+
+class VitOnnxExporter:
+    def __init__(self, exporter: OnnxExporter | None = None):
+        self.exporter = exporter or OnnxExporter()
+
+    def export(
+        self,
+        model: nn.Module,
+        onnx_path: Path,
+        *,
+        opset: int = 17,
+        do_constant_folding: bool = True,
+    ) -> Path:
+        input_h, input_w = resolve_input_hw(model.vit.input_size)
+        device = next(model.parameters()).device
+        dummy_target_t = torch.randn(1, 1, model.vit.in_channels, input_h, input_w, device=device)
+        dummy_context_frames = max(1, int(getattr(model.vit, "max_num_frames", 2)) - 1)
+        dummy_context = torch.randn(
+            1,
+            dummy_context_frames,
+            model.vit.in_channels,
+            input_h,
+            input_w,
+            device=device,
+        )
+        dummy_t = torch.rand(1, device=device)
+        dummy_frame_rate = torch.ones(1, device=device)
+        wrapper = VitOnnxWrapper(model.vit).eval()
+        return self.exporter.export(
+            wrapper,
+            (dummy_target_t, dummy_context, dummy_t, dummy_frame_rate),
+            onnx_path,
+            input_names=["target_t", "context", "t", "frame_rate"],
+            output_names=["output"],
+            opset=opset,
+            do_constant_folding=do_constant_folding,
+            dynamic_axes={
+                "target_t": {0: "batch"},
+                "context": {0: "batch", 1: "context_frames"},
+                "t": {0: "batch"},
+                "frame_rate": {0: "batch"},
+                "output": {0: "batch"},
+            },
+        )
+
+
+def resolve_input_hw(input_size: object) -> tuple[int, int]:
+    if isinstance(input_size, (list, tuple, ListConfig)):
+        return int(input_size[0]), int(input_size[1])
+    size = int(input_size)
+    return size, size
+
+
+def make_vit_inputs(
+    vit: nn.Module,
+    batch_size: int,
+    context_frames: int,
+    target_frames: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    input_size = getattr(vit, "input_size", None)
+    in_channels = getattr(vit, "in_channels", None)
+    if input_size is None or in_channels is None:
+        raise ValueError("model.vit must expose input_size and in_channels")
+
+    height, width = resolve_input_hw(input_size)
+    target_t = torch.randn(batch_size, target_frames, in_channels, height, width, dtype=torch.float32)
+    context = torch.randn(batch_size, context_frames, in_channels, height, width, dtype=torch.float32)
+    t = torch.rand(batch_size, dtype=torch.float32)
+    frame_rate = torch.ones(batch_size, dtype=torch.float32)
+    return target_t, context, t, frame_rate

--- a/export/debug_runner.py
+++ b/export/debug_runner.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+
+from export.common import OnnxExporter, OnnxSessionFactory
+
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+GREEN = "\033[92m"
+RED = "\033[91m"
+CYAN = "\033[96m"
+
+
+def style(text: str, *codes: str) -> str:
+    return "".join(codes) + text + RESET
+
+
+def status_badge(ok: bool) -> str:
+    return style(" PASS ", BOLD, GREEN) if ok else style(" FAIL ", BOLD, RED)
+
+
+@dataclass(frozen=True)
+class SampleComparison:
+    ok: bool
+    max_abs_diff: float
+    mean_abs_diff: float
+
+
+@dataclass(frozen=True)
+class ParitySuiteSummary:
+    captured: SampleComparison
+    mismatches: int
+    worst_max_abs_diff: float
+    worst_mean_abs_diff: float
+
+
+@dataclass(frozen=True)
+class NamedSampleComparison:
+    results: Mapping[str, SampleComparison]
+
+
+@dataclass(frozen=True)
+class NamedParitySuiteSummary:
+    captured: NamedSampleComparison
+    mismatches: Mapping[str, int]
+    worst_max_abs_diff: Mapping[str, float]
+    worst_mean_abs_diff: Mapping[str, float]
+
+
+class SingleOutputParityRunner:
+    def __init__(
+        self,
+        exporter: OnnxExporter,
+        session_factory: OnnxSessionFactory,
+        *,
+        atol: float,
+        rtol: float,
+    ):
+        self.exporter = exporter
+        self.session_factory = session_factory
+        self.atol = atol
+        self.rtol = rtol
+
+    def build_indexed_ort_inputs(self, inputs: Sequence[torch.Tensor]) -> dict[str, object]:
+        return {
+            f"input_{index}": tensor.cpu().numpy()
+            for index, tensor in enumerate(inputs)
+        }
+
+    def export_and_create_session(
+        self,
+        module: nn.Module,
+        sample_inputs: Sequence[torch.Tensor],
+        onnx_path: Path,
+        *,
+        input_names: Sequence[str],
+        output_names: Sequence[str],
+        opset: int,
+        do_constant_folding: bool = True,
+        disable_optimizations: bool = False,
+    ) -> tuple[str, ort.InferenceSession]:
+        exported_path = self.exporter.export(
+            module,
+            tuple(sample_inputs),
+            onnx_path,
+            input_names=input_names,
+            output_names=output_names,
+            opset=opset,
+            do_constant_folding=do_constant_folding,
+        )
+        session = self.session_factory.create_cpu_session(
+            exported_path,
+            disable_optimizations=disable_optimizations,
+        )
+        return str(exported_path), session
+
+    def compare_sample(
+        self,
+        module: nn.Module,
+        session: ort.InferenceSession,
+        module_inputs: Sequence[torch.Tensor],
+        ort_inputs: dict[str, object] | None = None,
+    ) -> SampleComparison:
+        with torch.no_grad():
+            pytorch_output = module(*tuple(module_inputs))
+
+        effective_ort_inputs = ort_inputs or self.build_indexed_ort_inputs(module_inputs)
+        ort_output = session.run(None, effective_ort_inputs)[0]
+        pytorch_output_np = pytorch_output.cpu().numpy()
+        abs_diff = abs(pytorch_output_np - ort_output)
+        max_abs_diff = float(abs_diff.max())
+        mean_abs_diff = float(abs_diff.mean())
+        ok = torch.allclose(
+            torch.from_numpy(ort_output),
+            torch.from_numpy(pytorch_output_np),
+            atol=self.atol,
+            rtol=self.rtol,
+        )
+        return SampleComparison(ok=ok, max_abs_diff=max_abs_diff, mean_abs_diff=mean_abs_diff)
+
+    def print_sample(self, label: str, result: SampleComparison) -> None:
+        print(
+            f"  {style(label, CYAN)} {status_badge(result.ok)} "
+            f"{style('max', DIM)}={result.max_abs_diff:.3e} "
+            f"{style('mean', DIM)}={result.mean_abs_diff:.3e}"
+        )
+
+    def run_same_shape_suite(
+        self,
+        module: nn.Module,
+        session: ort.InferenceSession,
+        captured_inputs: Sequence[torch.Tensor],
+        *,
+        num_samples: int,
+        random_input_factory: Callable[[], Sequence[torch.Tensor]],
+        captured_label: str = "Captured sample",
+        random_label: str = "Random sample",
+    ) -> ParitySuiteSummary:
+        captured_result = self.compare_sample(module, session, captured_inputs)
+        self.print_sample(captured_label, captured_result)
+
+        worst_max_abs_diff = captured_result.max_abs_diff
+        worst_mean_abs_diff = captured_result.mean_abs_diff
+        mismatches = 0 if captured_result.ok else 1
+
+        for sample_index in range(num_samples):
+            sample_inputs = tuple(random_input_factory())
+            sample_result = self.compare_sample(module, session, sample_inputs)
+            if not sample_result.ok:
+                mismatches += 1
+            worst_max_abs_diff = max(worst_max_abs_diff, sample_result.max_abs_diff)
+            worst_mean_abs_diff = max(worst_mean_abs_diff, sample_result.mean_abs_diff)
+            self.print_sample(f"{random_label} {sample_index + 1:02d}/{num_samples}", sample_result)
+
+        return ParitySuiteSummary(
+            captured=captured_result,
+            mismatches=mismatches,
+            worst_max_abs_diff=worst_max_abs_diff,
+            worst_mean_abs_diff=worst_mean_abs_diff,
+        )
+
+
+class NamedOutputParityRunner(SingleOutputParityRunner):
+    def compare_named_sample(
+        self,
+        module: nn.Module,
+        session: ort.InferenceSession,
+        module_inputs: Sequence[torch.Tensor],
+        *,
+        output_names: Sequence[str],
+        ort_inputs: dict[str, object] | None = None,
+    ) -> NamedSampleComparison:
+        with torch.no_grad():
+            pytorch_outputs = module(*tuple(module_inputs))
+
+        if not isinstance(pytorch_outputs, tuple):
+            pytorch_outputs = (pytorch_outputs,)
+
+        effective_ort_inputs = ort_inputs or self.build_indexed_ort_inputs(module_inputs)
+        ort_outputs = session.run(None, effective_ort_inputs)
+        results: dict[str, SampleComparison] = {}
+
+        for output_name, pytorch_output, ort_output in zip(output_names, pytorch_outputs, ort_outputs):
+            pytorch_output_np = pytorch_output.cpu().numpy()
+            abs_diff = abs(pytorch_output_np - ort_output)
+            max_abs_diff = float(abs_diff.max())
+            mean_abs_diff = float(abs_diff.mean())
+            ok = torch.allclose(
+                torch.from_numpy(ort_output),
+                torch.from_numpy(pytorch_output_np),
+                atol=self.atol,
+                rtol=self.rtol,
+            )
+            results[output_name] = SampleComparison(
+                ok=ok,
+                max_abs_diff=max_abs_diff,
+                mean_abs_diff=mean_abs_diff,
+            )
+
+        return NamedSampleComparison(results=results)
+
+    def print_named_sample(self, label: str, result: NamedSampleComparison) -> None:
+        print(f"  {style(label, CYAN)}")
+        for output_name, comparison in result.results.items():
+            print(
+                f"    {output_name} {status_badge(comparison.ok)} "
+                f"{style('max', DIM)}={comparison.max_abs_diff:.3e} "
+                f"{style('mean', DIM)}={comparison.mean_abs_diff:.3e}"
+            )
+
+    def run_named_same_shape_suite(
+        self,
+        module: nn.Module,
+        session: ort.InferenceSession,
+        captured_inputs: Sequence[torch.Tensor],
+        *,
+        output_names: Sequence[str],
+        num_samples: int,
+        random_input_factory: Callable[[], Sequence[torch.Tensor]],
+        captured_label: str = "Captured sample",
+        random_label: str = "Random sample",
+    ) -> NamedParitySuiteSummary:
+        captured_result = self.compare_named_sample(
+            module,
+            session,
+            captured_inputs,
+            output_names=output_names,
+        )
+        self.print_named_sample(captured_label, captured_result)
+
+        mismatches = {
+            output_name: 0 if comparison.ok else 1
+            for output_name, comparison in captured_result.results.items()
+        }
+        worst_max_abs_diff = {
+            output_name: comparison.max_abs_diff
+            for output_name, comparison in captured_result.results.items()
+        }
+        worst_mean_abs_diff = {
+            output_name: comparison.mean_abs_diff
+            for output_name, comparison in captured_result.results.items()
+        }
+
+        for sample_index in range(num_samples):
+            sample_inputs = tuple(random_input_factory())
+            sample_result = self.compare_named_sample(
+                module,
+                session,
+                sample_inputs,
+                output_names=output_names,
+            )
+            self.print_named_sample(f"{random_label} {sample_index + 1:02d}/{num_samples}", sample_result)
+            for output_name, comparison in sample_result.results.items():
+                if not comparison.ok:
+                    mismatches[output_name] += 1
+                worst_max_abs_diff[output_name] = max(worst_max_abs_diff[output_name], comparison.max_abs_diff)
+                worst_mean_abs_diff[output_name] = max(worst_mean_abs_diff[output_name], comparison.mean_abs_diff)
+
+        return NamedParitySuiteSummary(
+            captured=captured_result,
+            mismatches=mismatches,
+            worst_max_abs_diff=worst_max_abs_diff,
+            worst_mean_abs_diff=worst_mean_abs_diff,
+        )

--- a/export/debug_space_mlp_core_onnx.py
+++ b/export/debug_space_mlp_core_onnx.py
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export only the norm2 -> modulate -> space_mlp core path inside one
+model.vit.blocks[i] block to ONNX and compare PyTorch vs ONNX Runtime.
+
+This excludes the final residual addition so we can determine whether the
+drift originates inside the MLP path itself or only when adding it back.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, make_vit_inputs
+from export.debug_runner import SingleOutputParityRunner
+from networks.DiT.dit import modulate
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=1)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+def _space_mlp_modulation(block: nn.Module, c: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    _, _, _, shift_mlp_s, scale_mlp_s, gate_mlp_s, *_ = block.adaLN_modulation(c).chunk(9, dim=1)
+    return shift_mlp_s, scale_mlp_s, gate_mlp_s
+
+
+class SpaceMlpCoreWrapper(nn.Module):
+    def __init__(self, block: nn.Module):
+        super().__init__()
+        self.block = block
+
+    def forward(self, x_after_attn: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        shift_mlp_s, scale_mlp_s, _gate_mlp_s = _space_mlp_modulation(self.block, c)
+        x_modulated = modulate(self.block.norm2(x_after_attn), shift_mlp_s, scale_mlp_s)
+        return self.block.space_mlp(x_modulated)
+
+
+def capture_space_mlp_core_io(
+    vit: nn.Module,
+    block_index: int,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> tuple[nn.Module, dict[str, torch.Tensor]]:
+    blocks = getattr(vit, "blocks", None)
+    if blocks is None:
+        raise ValueError("model.vit does not expose blocks")
+    if block_index < 0 or block_index >= len(blocks):
+        raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+    block = blocks[block_index]
+    captured: dict[str, torch.Tensor] = {}
+
+    def block_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x_in"] = inputs[0].detach().cpu().clone()
+        captured["c"] = inputs[1].detach().cpu().clone()
+
+    def norm_time_attn_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x_after_spatial"] = inputs[0].detach().cpu().clone()
+
+    handles = [
+        block.register_forward_pre_hook(block_pre_hook),
+        block.norm_time_attn.register_forward_pre_hook(norm_time_attn_pre_hook),
+    ]
+
+    try:
+        with torch.no_grad():
+            vit(target_t, context, t, frame_rate=frame_rate)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    if "x_in" not in captured or "c" not in captured or "x_after_spatial" not in captured:
+        raise RuntimeError("Failed to capture spatial tensors for MLP core")
+
+    shift_msa_s, scale_msa_s, gate_msa_s, shift_mlp_s, scale_mlp_s, gate_mlp_s, *_ = block.adaLN_modulation(captured["c"]).chunk(9, dim=1)
+    batch_size, frame_count, _, _ = captured["x_in"].shape
+    with torch.no_grad():
+        x_modulated = modulate(block.norm1(captured["x_in"]), shift_msa_s, scale_msa_s)
+        x_modulated = x_modulated.reshape(batch_size * frame_count, x_modulated.shape[2], x_modulated.shape[3])
+        x_attn = block.space_attn(x_modulated)
+        x_attn = x_attn.reshape(batch_size, frame_count, x_attn.shape[1], x_attn.shape[2])
+        x_after_attn = captured["x_in"] + gate_msa_s.unsqueeze(1).unsqueeze(1) * x_attn
+        x_core = block.space_mlp(modulate(block.norm2(x_after_attn), shift_mlp_s, scale_mlp_s))
+
+    captured["x_after_attn"] = x_after_attn.detach().cpu().clone()
+    captured["x_core"] = x_core.detach().cpu().clone()
+    captured["x_reconstructed_after_spatial"] = (x_after_attn + gate_mlp_s.unsqueeze(1).unsqueeze(1) * x_core).detach().cpu().clone()
+    return block, captured
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("Space MLP Core ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Capturing real MLP-core tensors...")
+    vit_inputs = make_vit_inputs(
+        model.vit,
+        batch_size=args.batch_size,
+        context_frames=args.context_frames,
+        target_frames=args.target_frames,
+    )
+    block, captured = capture_space_mlp_core_io(
+        model.vit,
+        args.block_index,
+        *vit_inputs,
+    )
+    wrapper = SpaceMlpCoreWrapper(block).eval()
+
+    print(f"  Block index: {args.block_index}")
+    print(f"  Block type: {type(block).__name__}")
+    print(f"  x_after_attn shape: {tuple(captured['x_after_attn'].shape)}")
+    print(f"  c shape: {tuple(captured['c'].shape)}")
+    print(f"  x_core shape: {tuple(captured['x_core'].shape)}")
+
+    with torch.no_grad():
+        wrapped_output = wrapper(captured["x_after_attn"], captured["c"])
+    verify_diff = (wrapped_output - captured["x_core"]).abs()
+    print(
+        f"  Wrapper vs captured MLP core: max_abs_diff={float(verify_diff.max()):.3e} "
+        f"mean_abs_diff={float(verify_diff.mean()):.3e}"
+    )
+
+    reconstruction_diff = (captured["x_reconstructed_after_spatial"] - captured["x_after_spatial"]).abs()
+    print(
+        f"  Reconstructed full spatial output vs captured: max_abs_diff={float(reconstruction_diff.max()):.3e} "
+        f"mean_abs_diff={float(reconstruction_diff.mean()):.3e}"
+    )
+
+    print("\n[3] Exporting MLP core to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        wrapper,
+        (captured["x_after_attn"], captured["c"]),
+        artifacts.onnx_path,
+        input_names=["input_0", "input_1"],
+        output_names=["output"],
+        opset=args.opset,
+    )
+    print(f"  Exported: {onnx_path}")
+
+    print("\n[4] Creating ONNX Runtime session...")
+    print("  Session ready")
+
+    print("\n[5] Comparing captured and random same-shape samples...")
+    summary = parity_runner.run_same_shape_suite(
+        wrapper,
+        session,
+        (captured["x_after_attn"], captured["c"]),
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            torch.randn_like(captured["x_after_attn"]),
+            torch.randn_like(captured["c"]),
+        ),
+    )
+
+    print("\n[6] Summary")
+    print(f"  Total mismatches including captured sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_spatial_path_onnx.py
+++ b/export/debug_spatial_path_onnx.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export the spatial path inside one model.vit.blocks[i] block to ONNX and
+compare PyTorch vs ONNX Runtime outputs on captured and random inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, make_vit_inputs
+from export.debug_runner import SingleOutputParityRunner
+from networks.DiT.dit import modulate
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=0)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+class SpatialPathWrapper(nn.Module):
+    def __init__(self, block: nn.Module):
+        super().__init__()
+        self.block = block
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        batch_size, frame_count, token_count, _ = x.shape
+        (
+            shift_msa_s,
+            scale_msa_s,
+            gate_msa_s,
+            shift_mlp_s,
+            scale_mlp_s,
+            gate_mlp_s,
+            _shift_mlp_t,
+            _scale_mlp_t,
+            _gate_mlp_t,
+        ) = self.block.adaLN_modulation(c).chunk(9, dim=1)
+
+        x_modulated = modulate(self.block.norm1(x), shift_msa_s, scale_msa_s)
+        x_modulated = rearrange(x_modulated, "b f n d -> (b f) n d", b=batch_size, f=frame_count)
+        x_attn = self.block.space_attn(x_modulated)
+        x_attn = rearrange(x_attn, "(b f) n d -> b f n d", b=batch_size, f=frame_count)
+        x = x + gate_msa_s.unsqueeze(1).unsqueeze(1) * x_attn
+
+        x_modulated = modulate(self.block.norm2(x), shift_mlp_s, scale_mlp_s)
+        x = x + gate_mlp_s.unsqueeze(1).unsqueeze(1) * self.block.space_mlp(x_modulated)
+        return x
+
+
+def capture_spatial_io(
+    vit: nn.Module,
+    block_index: int,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> tuple[nn.Module, torch.Tensor, torch.Tensor, torch.Tensor]:
+    blocks = getattr(vit, "blocks", None)
+    if blocks is None:
+        raise ValueError("model.vit does not expose blocks")
+
+    if block_index < 0 or block_index >= len(blocks):
+        raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+    block = blocks[block_index]
+    captured: dict[str, torch.Tensor] = {}
+
+    def block_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x"] = inputs[0].detach().cpu().clone()
+        captured["c"] = inputs[1].detach().cpu().clone()
+
+    def post_spatial_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["spatial_output"] = inputs[0].detach().cpu().clone()
+
+    handles = [
+        block.register_forward_pre_hook(block_pre_hook),
+        block.norm_time_attn.register_forward_pre_hook(post_spatial_hook),
+    ]
+
+    try:
+        with torch.no_grad():
+            vit(target_t, context, t, frame_rate=frame_rate)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    if "x" not in captured or "c" not in captured or "spatial_output" not in captured:
+        raise RuntimeError("Failed to capture spatial path tensors from model.vit forward")
+
+    return block, captured["x"], captured["c"], captured["spatial_output"]
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("Spatial Path ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Capturing real spatial-path inputs...")
+    vit_inputs = make_vit_inputs(
+        model.vit,
+        batch_size=args.batch_size,
+        context_frames=args.context_frames,
+        target_frames=args.target_frames,
+    )
+    block, captured_x, captured_c, captured_spatial_output = capture_spatial_io(
+        model.vit,
+        args.block_index,
+        *vit_inputs,
+    )
+    wrapper = SpatialPathWrapper(block)
+    wrapper.eval()
+
+    print(f"  Block index: {args.block_index}")
+    print(f"  Block type: {type(block).__name__}")
+    print(f"  Spatial-path x shape: {tuple(captured_x.shape)}")
+    print(f"  Conditioning c shape: {tuple(captured_c.shape)}")
+    print(f"  Spatial-path output shape: {tuple(captured_spatial_output.shape)}")
+    print(f"  shift_size: {getattr(block.space_attn, 'shift_size', None)}")
+
+    print("\n[3] Verifying wrapper matches captured spatial-path continuation...")
+    with torch.no_grad():
+        wrapped_output = wrapper(captured_x, captured_c)
+    wrapper_vs_captured_diff = (wrapped_output - captured_spatial_output).abs()
+    print(
+        f"  Wrapper vs captured spatial output: max_abs_diff={float(wrapper_vs_captured_diff.max()):.3e} "
+        f"mean_abs_diff={float(wrapper_vs_captured_diff.mean()):.3e}"
+    )
+
+    print("\n[4] Exporting spatial path to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        wrapper,
+        (captured_x, captured_c),
+        artifacts.onnx_path,
+        input_names=["input_0", "input_1"],
+        output_names=["output"],
+        opset=args.opset,
+    )
+    print(f"  Exported: {onnx_path}")
+
+    print("\n[5] Creating ONNX Runtime session...")
+    print("  Session ready")
+
+    print("\n[6] Comparing captured and random same-shape samples...")
+    summary = parity_runner.run_same_shape_suite(
+        wrapper,
+        session,
+        (captured_x, captured_c),
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            torch.randn_like(captured_x),
+            torch.randn_like(captured_c),
+        ),
+    )
+
+    print("\n[7] Summary")
+    print(f"  Random samples tested: {args.num_samples}")
+    print(f"  Total mismatches including captured sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+    if summary.mismatches == 0:
+        print("  Result: spatial path exports correctly and matches ONNX Runtime within tolerance")
+    else:
+        print("  Result: spatial path exports, but ONNX Runtime output diverges from PyTorch")
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_spatial_path_stages_onnx.py
+++ b/export/debug_spatial_path_stages_onnx.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export the full spatial path inside one model.vit.blocks[i] block to ONNX,
+returning both intermediate stage outputs:
+1. after space_attn + residual
+2. after space_mlp + residual
+
+This lets us compare PyTorch vs ONNX Runtime at both points inside one graph.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, make_vit_inputs
+from export.debug_runner import NamedOutputParityRunner
+from networks.DiT.dit import modulate
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+OUTPUT_NAMES = ["after_attn", "after_mlp"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=1)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    parser.add_argument("--disable-constant-folding", action="store_true")
+    parser.add_argument("--disable-ort-optimizations", action="store_true")
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+def _spatial_modulation(block: nn.Module, c: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    shift_msa_s, scale_msa_s, gate_msa_s, shift_mlp_s, scale_mlp_s, gate_mlp_s, *_ = block.adaLN_modulation(c).chunk(9, dim=1)
+    return shift_msa_s, scale_msa_s, gate_msa_s, shift_mlp_s, scale_mlp_s, gate_mlp_s
+
+
+class SpatialStagesWrapper(nn.Module):
+    def __init__(self, block: nn.Module):
+        super().__init__()
+        self.block = block
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size, frame_count, _, _ = x.shape
+        shift_msa_s, scale_msa_s, gate_msa_s, shift_mlp_s, scale_mlp_s, gate_mlp_s = _spatial_modulation(self.block, c)
+
+        x_modulated = modulate(self.block.norm1(x), shift_msa_s, scale_msa_s)
+        x_modulated = rearrange(x_modulated, "b f n d -> (b f) n d", b=batch_size, f=frame_count)
+        x_attn = self.block.space_attn(x_modulated)
+        x_attn = rearrange(x_attn, "(b f) n d -> b f n d", b=batch_size, f=frame_count)
+        x_after_attn = x + gate_msa_s.unsqueeze(1).unsqueeze(1) * x_attn
+
+        x_modulated = modulate(self.block.norm2(x_after_attn), shift_mlp_s, scale_mlp_s)
+        x_after_mlp = x_after_attn + gate_mlp_s.unsqueeze(1).unsqueeze(1) * self.block.space_mlp(x_modulated)
+        return x_after_attn, x_after_mlp
+
+
+def capture_spatial_stage_io(
+    vit: nn.Module,
+    block_index: int,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> tuple[nn.Module, dict[str, torch.Tensor]]:
+    blocks = getattr(vit, "blocks", None)
+    if blocks is None:
+        raise ValueError("model.vit does not expose blocks")
+    if block_index < 0 or block_index >= len(blocks):
+        raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+    block = blocks[block_index]
+    captured: dict[str, torch.Tensor] = {}
+    wrapper = SpatialStagesWrapper(block)
+
+    def block_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x_in"] = inputs[0].detach().cpu().clone()
+        captured["c"] = inputs[1].detach().cpu().clone()
+
+    def norm_time_attn_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x_after_spatial"] = inputs[0].detach().cpu().clone()
+
+    handles = [
+        block.register_forward_pre_hook(block_pre_hook),
+        block.norm_time_attn.register_forward_pre_hook(norm_time_attn_pre_hook),
+    ]
+
+    try:
+        with torch.no_grad():
+            vit(target_t, context, t, frame_rate=frame_rate)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    if "x_in" not in captured or "c" not in captured or "x_after_spatial" not in captured:
+        raise RuntimeError("Failed to capture spatial stage tensors")
+
+    with torch.no_grad():
+        x_after_attn, x_after_mlp = wrapper(captured["x_in"], captured["c"])
+        captured["x_after_attn"] = x_after_attn.detach().cpu().clone()
+        captured["x_after_mlp"] = x_after_mlp.detach().cpu().clone()
+
+    return block, captured
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = NamedOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("Spatial Path Stages ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Capturing real spatial stage tensors...")
+    vit_inputs = make_vit_inputs(
+        model.vit,
+        batch_size=args.batch_size,
+        context_frames=args.context_frames,
+        target_frames=args.target_frames,
+    )
+    block, captured = capture_spatial_stage_io(
+        model.vit,
+        args.block_index,
+        *vit_inputs,
+    )
+    wrapper = SpatialStagesWrapper(block).eval()
+
+    print(f"  Block index: {args.block_index}")
+    print(f"  Block type: {type(block).__name__}")
+    print(f"  shift_size: {getattr(block.space_attn, 'shift_size', None)}")
+    print(f"  x_in shape: {tuple(captured['x_in'].shape)}")
+    print(f"  c shape: {tuple(captured['c'].shape)}")
+    print(f"  x_after_attn shape: {tuple(captured['x_after_attn'].shape)}")
+    print(f"  x_after_mlp shape: {tuple(captured['x_after_mlp'].shape)}")
+
+    stage_reconstruction_diff = (captured["x_after_mlp"] - captured["x_after_spatial"]).abs()
+    print(
+        f"  Captured reconstruction vs spatial continuation: max_abs_diff={float(stage_reconstruction_diff.max()):.3e} "
+        f"mean_abs_diff={float(stage_reconstruction_diff.mean()):.3e}"
+    )
+
+    print("\n[3] Exporting staged spatial graph to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        wrapper,
+        (captured["x_in"], captured["c"]),
+        artifacts.onnx_path,
+        input_names=["input_0", "input_1"],
+        output_names=OUTPUT_NAMES,
+        opset=args.opset,
+        do_constant_folding=not args.disable_constant_folding,
+        disable_optimizations=args.disable_ort_optimizations,
+    )
+    print(f"  Exported: {onnx_path}")
+    print(f"  Constant folding enabled: {not args.disable_constant_folding}")
+
+    print("\n[4] Creating ONNX Runtime session...")
+    print("  Session ready")
+    print(f"  ORT graph optimizations enabled: {not args.disable_ort_optimizations}")
+
+    print("\n[5] Comparing captured and random same-shape samples...")
+    summary = parity_runner.run_named_same_shape_suite(
+        wrapper,
+        session,
+        (captured["x_in"], captured["c"]),
+        output_names=OUTPUT_NAMES,
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            torch.randn_like(captured["x_in"]),
+            torch.randn_like(captured["c"]),
+        ),
+    )
+
+    print("\n[6] Summary")
+    for key in OUTPUT_NAMES:
+        print(
+            f"  {key}: mismatches={summary.mismatches[key]} worst_max_abs_diff={summary.worst_max_abs_diff[key]:.3e} "
+            f"worst_mean_abs_diff={summary.worst_mean_abs_diff[key]:.3e}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_spatial_subpaths_onnx.py
+++ b/export/debug_spatial_subpaths_onnx.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export the two spatial subpaths inside one model.vit.blocks[i] block to ONNX
+and compare PyTorch vs ONNX Runtime outputs:
+1. space_attn + residual
+2. space_mlp + residual
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, make_vit_inputs
+from export.debug_runner import SingleOutputParityRunner
+from networks.DiT.dit import modulate
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=1)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+def _spatial_modulation(block: nn.Module, c: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    shift_msa_s, scale_msa_s, gate_msa_s, shift_mlp_s, scale_mlp_s, gate_mlp_s, *_ = block.adaLN_modulation(c).chunk(9, dim=1)
+    return shift_msa_s, scale_msa_s, gate_msa_s, shift_mlp_s, scale_mlp_s, gate_mlp_s
+
+
+class SpaceAttnResidualWrapper(nn.Module):
+    def __init__(self, block: nn.Module):
+        super().__init__()
+        self.block = block
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        batch_size, frame_count, _, _ = x.shape
+        shift_msa_s, scale_msa_s, gate_msa_s, *_ = _spatial_modulation(self.block, c)
+        x_modulated = modulate(self.block.norm1(x), shift_msa_s, scale_msa_s)
+        x_modulated = rearrange(x_modulated, "b f n d -> (b f) n d", b=batch_size, f=frame_count)
+        x_attn = self.block.space_attn(x_modulated)
+        x_attn = rearrange(x_attn, "(b f) n d -> b f n d", b=batch_size, f=frame_count)
+        return x + gate_msa_s.unsqueeze(1).unsqueeze(1) * x_attn
+
+
+class SpaceMlpResidualWrapper(nn.Module):
+    def __init__(self, block: nn.Module):
+        super().__init__()
+        self.block = block
+
+    def forward(self, x_after_attn: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        *_, shift_mlp_s, scale_mlp_s, gate_mlp_s = _spatial_modulation(self.block, c)
+        x_modulated = modulate(self.block.norm2(x_after_attn), shift_mlp_s, scale_mlp_s)
+        return x_after_attn + gate_mlp_s.unsqueeze(1).unsqueeze(1) * self.block.space_mlp(x_modulated)
+
+
+def capture_spatial_subpath_io(
+    vit: nn.Module,
+    block_index: int,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> tuple[nn.Module, dict[str, torch.Tensor]]:
+    blocks = getattr(vit, "blocks", None)
+    if blocks is None:
+        raise ValueError("model.vit does not expose blocks")
+    if block_index < 0 or block_index >= len(blocks):
+        raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+    block = blocks[block_index]
+    captured: dict[str, torch.Tensor] = {}
+
+    attn_wrapper = SpaceAttnResidualWrapper(block)
+    mlp_wrapper = SpaceMlpResidualWrapper(block)
+
+    def block_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x_in"] = inputs[0].detach().cpu().clone()
+        captured["c"] = inputs[1].detach().cpu().clone()
+
+    def norm_time_attn_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x_after_spatial"] = inputs[0].detach().cpu().clone()
+
+    handles = [
+        block.register_forward_pre_hook(block_pre_hook),
+        block.norm_time_attn.register_forward_pre_hook(norm_time_attn_pre_hook),
+    ]
+
+    try:
+        with torch.no_grad():
+            vit(target_t, context, t, frame_rate=frame_rate)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    if "x_in" not in captured or "c" not in captured or "x_after_spatial" not in captured:
+        raise RuntimeError("Failed to capture spatial subpath tensors")
+
+    with torch.no_grad():
+        captured["x_after_attn"] = attn_wrapper(captured["x_in"], captured["c"]).detach().cpu().clone()
+        captured["x_after_mlp"] = mlp_wrapper(captured["x_after_attn"], captured["c"]).detach().cpu().clone()
+
+    return block, captured
+
+
+def run_subpath_test(
+    *,
+    title: str,
+    wrapper: nn.Module,
+    captured_x: torch.Tensor,
+    captured_c: torch.Tensor,
+    expected_output: torch.Tensor,
+    num_samples: int,
+    onnx_path: Path,
+    opset: int,
+    atol: float,
+    rtol: float,
+) -> None:
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=atol, rtol=rtol)
+    print(f"\n[{title}]")
+    with torch.no_grad():
+        wrapped_output = wrapper(captured_x, captured_c)
+    verify_diff = (wrapped_output - expected_output).abs()
+    print(
+        f"  Wrapper vs captured output: max_abs_diff={float(verify_diff.max()):.3e} "
+        f"mean_abs_diff={float(verify_diff.mean()):.3e}"
+    )
+
+    exported_onnx_path, session = parity_runner.export_and_create_session(
+        wrapper,
+        (captured_x, captured_c),
+        onnx_path,
+        input_names=["input_0", "input_1"],
+        output_names=["output"],
+        opset=opset,
+    )
+    summary = parity_runner.run_same_shape_suite(
+        wrapper,
+        session,
+        (captured_x, captured_c),
+        num_samples=num_samples,
+        random_input_factory=lambda: (
+            torch.randn_like(captured_x),
+            torch.randn_like(captured_c),
+        ),
+    )
+    print(f"  Total mismatches including captured sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+
+    print("=" * 60)
+    print("Spatial Subpaths ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Capturing real spatial subpath tensors...")
+    vit_inputs = make_vit_inputs(
+        model.vit,
+        batch_size=args.batch_size,
+        context_frames=args.context_frames,
+        target_frames=args.target_frames,
+    )
+    block, captured = capture_spatial_subpath_io(
+        model.vit,
+        args.block_index,
+        *vit_inputs,
+    )
+    print(f"  Block index: {args.block_index}")
+    print(f"  Block type: {type(block).__name__}")
+    print(f"  shift_size: {getattr(block.space_attn, 'shift_size', None)}")
+    print(f"  x_in shape: {tuple(captured['x_in'].shape)}")
+    print(f"  c shape: {tuple(captured['c'].shape)}")
+    print(f"  x_after_attn shape: {tuple(captured['x_after_attn'].shape)}")
+    print(f"  x_after_mlp shape: {tuple(captured['x_after_mlp'].shape)}")
+    print(f"  captured full spatial output shape: {tuple(captured['x_after_spatial'].shape)}")
+
+    run_subpath_test(
+        title="3. Testing space_attn + residual",
+        wrapper=SpaceAttnResidualWrapper(block).eval(),
+        captured_x=captured["x_in"],
+        captured_c=captured["c"],
+        expected_output=captured["x_after_attn"],
+        num_samples=args.num_samples,
+        onnx_path=artifacts.onnx_path,
+        opset=args.opset,
+        atol=args.atol,
+        rtol=args.rtol,
+    )
+
+    run_subpath_test(
+        title="4. Testing space_mlp + residual",
+        wrapper=SpaceMlpResidualWrapper(block).eval(),
+        captured_x=captured["x_after_attn"],
+        captured_c=captured["c"],
+        expected_output=captured["x_after_mlp"],
+        num_samples=args.num_samples,
+        onnx_path=artifacts.onnx_path,
+        opset=args.opset,
+        atol=args.atol,
+        rtol=args.rtol,
+    )
+
+    spatial_reconstruction_diff = (captured["x_after_mlp"] - captured["x_after_spatial"]).abs()
+    print("\n[5] Captured pipeline consistency")
+    print(
+        f"  Reconstructed spatial output vs captured continuation: "
+        f"max_abs_diff={float(spatial_reconstruction_diff.max()):.3e} "
+        f"mean_abs_diff={float(spatial_reconstruction_diff.mean()):.3e}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_stdit_block_onnx.py
+++ b/export/debug_stdit_block_onnx.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export one full model.vit.blocks[i] block to ONNX and compare PyTorch vs
+ONNX Runtime outputs on captured and random same-shape inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, make_vit_inputs
+from export.debug_runner import SingleOutputParityRunner
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=0)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+def capture_block_io(
+    vit: nn.Module,
+    block_index: int,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> tuple[nn.Module, torch.Tensor, torch.Tensor, torch.Tensor]:
+    blocks = getattr(vit, "blocks", None)
+    if blocks is None:
+        raise ValueError("model.vit does not expose blocks")
+
+    if block_index < 0 or block_index >= len(blocks):
+        raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+    block = blocks[block_index]
+    captured: dict[str, torch.Tensor] = {}
+
+    def hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...], output: torch.Tensor) -> None:
+        captured["x"] = inputs[0].detach().cpu().clone()
+        captured["c"] = inputs[1].detach().cpu().clone()
+        captured["output"] = output.detach().cpu().clone()
+
+    handle = block.register_forward_hook(hook)
+    try:
+        with torch.no_grad():
+            vit(target_t, context, t, frame_rate=frame_rate)
+    finally:
+        handle.remove()
+
+    if not captured:
+        raise RuntimeError("Failed to capture block inputs from model.vit forward")
+
+    return block, captured["x"], captured["c"], captured["output"]
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("STDiT Block ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Capturing real inputs for model.vit.blocks[i]...")
+    vit_inputs = make_vit_inputs(
+        model.vit,
+        batch_size=args.batch_size,
+        context_frames=args.context_frames,
+        target_frames=args.target_frames,
+    )
+    block, captured_x, captured_c, captured_output = capture_block_io(
+        model.vit,
+        args.block_index,
+        *vit_inputs,
+    )
+    block.eval()
+    print(f"  Block index: {args.block_index}")
+    print(f"  Block type: {type(block).__name__}")
+    print(f"  Captured x shape: {tuple(captured_x.shape)}")
+    print(f"  Captured c shape: {tuple(captured_c.shape)}")
+    print(f"  Captured output shape: {tuple(captured_output.shape)}")
+
+    print("\n[3] Exporting block to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        block,
+        (captured_x, captured_c),
+        artifacts.onnx_path,
+        input_names=["input_0", "input_1"],
+        output_names=["output"],
+        opset=args.opset,
+    )
+    print(f"  Exported: {onnx_path}")
+
+    print("\n[4] Creating ONNX Runtime session...")
+    print("  Session ready")
+
+    print("\n[5] Comparing captured and random same-shape samples...")
+    summary = parity_runner.run_same_shape_suite(
+        block,
+        session,
+        (captured_x, captured_c),
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            torch.randn_like(captured_x),
+            torch.randn_like(captured_c),
+        ),
+    )
+
+    print("\n[6] Summary")
+    print(f"  Random samples tested: {args.num_samples}")
+    print(f"  Total mismatches including captured sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+    if summary.mismatches == 0:
+        print("  Result: model.vit.blocks[i] exports correctly and matches ONNX Runtime within tolerance")
+    else:
+        print("  Result: model.vit.blocks[i] exports, but ONNX Runtime output diverges from PyTorch")
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_swin_block_onnx.py
+++ b/export/debug_swin_block_onnx.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export a single SwinTransformerBlock to ONNX and compare PyTorch vs
+ONNX Runtime outputs on multiple random samples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory
+from export.debug_runner import SingleOutputParityRunner
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--module-index", type=int, default=0)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+def find_swin_block(model: nn.Module, module_index: int) -> tuple[str, nn.Module]:
+    matches: list[tuple[str, nn.Module]] = []
+    for name, module in model.vit.named_modules():
+        if type(module).__name__ == "SwinTransformerBlock":
+            matches.append((name, module))
+
+    if not matches:
+        raise RuntimeError("No SwinTransformerBlock modules found")
+
+    if module_index < 0 or module_index >= len(matches):
+        raise IndexError(f"module_index must be in [0, {len(matches) - 1}]")
+
+    return matches[module_index]
+
+
+def derive_input_shape(module: nn.Module, batch_size: int) -> tuple[int, int, int, tuple[int, int]]:
+    input_resolution = getattr(module, "input_resolution", None)
+    if input_resolution is None:
+        raise ValueError("SwinTransformerBlock does not expose input_resolution")
+
+    channel_count = getattr(module, "dim", None)
+    if channel_count is None:
+        raise ValueError("SwinTransformerBlock does not expose dim")
+
+    token_count = int(input_resolution[0] * input_resolution[1])
+    return batch_size, token_count, channel_count, tuple(input_resolution)
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("SwinTransformerBlock ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Selecting SwinTransformerBlock module...")
+    module_name, block = find_swin_block(model, args.module_index)
+    block.eval()
+    print(f"  Module: {module_name}")
+
+    batch_size, token_count, channel_count, input_resolution = derive_input_shape(block, args.batch_size)
+    print(
+        "  Derived shape: "
+        f"batch={batch_size}, resolution={input_resolution}, tokens={token_count}, channels={channel_count}"
+    )
+    print(f"  Shift size: {getattr(block, 'shift_size', None)}")
+    print(f"  Window size: {getattr(block, 'window_size', None)}")
+
+    export_x = torch.randn(batch_size, token_count, channel_count, dtype=torch.float32)
+
+    print("\n[3] Exporting to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        block,
+        (export_x,),
+        artifacts.onnx_path,
+        input_names=["input_0"],
+        output_names=["output"],
+        opset=args.opset,
+    )
+    print(f"  Exported: {onnx_path}")
+
+    print("\n[4] Creating ONNX Runtime session...")
+    print("  Session ready")
+
+    print("\n[5] Comparing PyTorch vs ONNX Runtime...")
+    summary = parity_runner.run_same_shape_suite(
+        block,
+        session,
+        (export_x,),
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            torch.randn(batch_size, token_count, channel_count, dtype=torch.float32),
+        ),
+        captured_label="Export sample",
+        random_label="Sample",
+    )
+
+    print("\n[6] Summary")
+    print(f"  Samples tested: {args.num_samples}")
+    print(f"  Mismatches including export sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+    if summary.mismatches == 0:
+        print("  Result: SwinTransformerBlock exports correctly and matches ONNX Runtime within tolerance")
+    else:
+        print("  Result: SwinTransformerBlock exports, but ONNX Runtime output diverges from PyTorch")
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_temporal_path_onnx.py
+++ b/export/debug_temporal_path_onnx.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export the temporal path inside one model.vit.blocks[i] block to ONNX and
+compare PyTorch vs ONNX Runtime outputs on captured and random inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, make_vit_inputs
+from export.debug_runner import SingleOutputParityRunner
+from networks.DiT.dit import modulate
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=0)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+class TemporalPathWrapper(nn.Module):
+    def __init__(self, block: nn.Module):
+        super().__init__()
+        self.block = block
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        batch_size, frame_count, token_count, _ = x.shape
+        (
+            _shift_msa,
+            _scale_msa,
+            _gate_msa,
+            _shift_mlp_s,
+            _scale_mlp_s,
+            _gate_mlp_s,
+            shift_mlp_t,
+            scale_mlp_t,
+            gate_mlp_t,
+        ) = self.block.adaLN_modulation(c).chunk(9, dim=1)
+
+        if self.block.modulate_time_attn:
+            shift_mta, scale_mta, gate_mta = self.block.adaLN_time_attn_modulation(c).chunk(3, dim=1)
+        else:
+            shift_mta = torch.zeros_like(shift_mlp_t)
+            scale_mta = torch.zeros_like(scale_mlp_t)
+            gate_mta = torch.ones_like(gate_mlp_t)
+
+        x_modulated = modulate(self.block.norm_time_attn(x), shift_mta, scale_mta)
+        x_modulated = rearrange(x_modulated, "b f n d -> (b n) f d", b=batch_size, f=frame_count, n=token_count)
+        time_attn_mask = torch.tril(torch.ones(frame_count, frame_count, device=x.device)) if self.block.causal_time_attn else None
+        x_attn = self.block.time_attn(x_modulated, attn_mask=time_attn_mask)
+        x_attn = rearrange(x_attn, "(b n) f d -> b f n d", b=batch_size, n=token_count, f=frame_count)
+        x = x + gate_mta.unsqueeze(1).unsqueeze(1) * x_attn
+
+        x_modulated = modulate(self.block.norm3(x), shift_mlp_t, scale_mlp_t)
+        x = x + gate_mlp_t.unsqueeze(1).unsqueeze(1) * self.block.time_mlp(x_modulated)
+        return x
+
+
+def capture_temporal_io(
+    vit: nn.Module,
+    block_index: int,
+    target_t: torch.Tensor,
+    context: torch.Tensor,
+    t: torch.Tensor,
+    frame_rate: torch.Tensor,
+) -> tuple[nn.Module, torch.Tensor, torch.Tensor, torch.Tensor]:
+    blocks = getattr(vit, "blocks", None)
+    if blocks is None:
+        raise ValueError("model.vit does not expose blocks")
+
+    if block_index < 0 or block_index >= len(blocks):
+        raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+    block = blocks[block_index]
+    captured: dict[str, torch.Tensor] = {}
+
+    def block_pre_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["c"] = inputs[1].detach().cpu().clone()
+
+    def temporal_input_hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
+        captured["x"] = inputs[0].detach().cpu().clone()
+
+    def block_hook(_module: nn.Module, _inputs: tuple[torch.Tensor, ...], output: torch.Tensor) -> None:
+        captured["output"] = output.detach().cpu().clone()
+
+    handles = [
+        block.register_forward_pre_hook(block_pre_hook),
+        block.norm_time_attn.register_forward_pre_hook(temporal_input_hook),
+        block.register_forward_hook(block_hook),
+    ]
+
+    try:
+        with torch.no_grad():
+            vit(target_t, context, t, frame_rate=frame_rate)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    if "x" not in captured or "c" not in captured or "output" not in captured:
+        raise RuntimeError("Failed to capture temporal path inputs from model.vit forward")
+
+    return block, captured["x"], captured["c"], captured["output"]
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("Temporal Path ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Capturing real temporal-path inputs...")
+    vit_inputs = make_vit_inputs(
+        model.vit,
+        batch_size=args.batch_size,
+        context_frames=args.context_frames,
+        target_frames=args.target_frames,
+    )
+    block, captured_x, captured_c, captured_block_output = capture_temporal_io(
+        model.vit,
+        args.block_index,
+        *vit_inputs,
+    )
+    wrapper = TemporalPathWrapper(block)
+    wrapper.eval()
+
+    print(f"  Block index: {args.block_index}")
+    print(f"  Block type: {type(block).__name__}")
+    print(f"  Temporal-path x shape: {tuple(captured_x.shape)}")
+    print(f"  Conditioning c shape: {tuple(captured_c.shape)}")
+    print(f"  Full block output shape: {tuple(captured_block_output.shape)}")
+    print(f"  causal_time_attn: {getattr(block, 'causal_time_attn', None)}")
+    print(f"  modulate_time_attn: {getattr(block, 'modulate_time_attn', None)}")
+
+    print("\n[3] Verifying wrapper matches captured full block continuation...")
+    with torch.no_grad():
+        wrapped_output = wrapper(captured_x, captured_c)
+    wrapper_vs_block_diff = (wrapped_output - captured_block_output).abs()
+    print(
+        f"  Wrapper vs full block output: max_abs_diff={float(wrapper_vs_block_diff.max()):.3e} "
+        f"mean_abs_diff={float(wrapper_vs_block_diff.mean()):.3e}"
+    )
+
+    print("\n[4] Exporting temporal path to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        wrapper,
+        (captured_x, captured_c),
+        artifacts.onnx_path,
+        input_names=["input_0", "input_1"],
+        output_names=["output"],
+        opset=args.opset,
+    )
+    print(f"  Exported: {onnx_path}")
+
+    print("\n[5] Creating ONNX Runtime session...")
+    print("  Session ready")
+
+    print("\n[6] Comparing captured and random same-shape samples...")
+    summary = parity_runner.run_same_shape_suite(
+        wrapper,
+        session,
+        (captured_x, captured_c),
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            torch.randn_like(captured_x),
+            torch.randn_like(captured_c),
+        ),
+    )
+
+    print("\n[7] Summary")
+    print(f"  Random samples tested: {args.num_samples}")
+    print(f"  Total mismatches including captured sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+    if summary.mismatches == 0:
+        print("  Result: temporal path exports correctly and matches ONNX Runtime within tolerance")
+    else:
+        print("  Result: temporal path exports, but ONNX Runtime output diverges from PyTorch")
+
+
+if __name__ == "__main__":
+    main()

--- a/export/debug_window_attention_onnx.py
+++ b/export/debug_window_attention_onnx.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+"""
+Export a single WindowAttention module to ONNX and compare PyTorch vs
+ONNX Runtime outputs on multiple random samples.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import onnx
+import onnxruntime as ort
+import torch
+import torch.nn as nn
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory
+from export.debug_runner import SingleOutputParityRunner
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--module-index", type=int, default=0)
+    parser.add_argument("--num-samples", type=int, default=10)
+    parser.add_argument("--batch-windows", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-5)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    parser.add_argument("--with-mask", action="store_true")
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def load_model(config_path: Path, ckpt_path: Path) -> nn.Module:
+    return MODEL_LOADER.load(config_path, ckpt_path)
+
+
+def find_window_attention(model: nn.Module, module_index: int) -> tuple[str, nn.Module]:
+    matches: list[tuple[str, nn.Module]] = []
+    for name, module in model.vit.named_modules():
+        if type(module).__name__ == "WindowAttention":
+            matches.append((name, module))
+
+    if not matches:
+        raise RuntimeError("No WindowAttention modules found")
+
+    if module_index < 0 or module_index >= len(matches):
+        raise IndexError(f"module_index must be in [0, {len(matches) - 1}]")
+
+    return matches[module_index]
+
+
+def derive_input_shape(module: nn.Module, batch_windows: int) -> tuple[int, int, int]:
+    window_size = getattr(module, "window_size", None)
+    if window_size is None:
+        raise ValueError("WindowAttention module does not expose window_size")
+
+    if isinstance(window_size, int):
+        token_count = window_size * window_size
+    else:
+        token_count = int(window_size[0] * window_size[1])
+
+    channel_count = getattr(module, "dim", None)
+    if channel_count is None and hasattr(module, "qkv"):
+        channel_count = module.qkv.in_features
+    if channel_count is None:
+        raise ValueError("WindowAttention module does not expose an input channel size")
+
+    return batch_windows, token_count, channel_count
+
+
+def build_mask(token_count: int) -> torch.Tensor:
+    mask = torch.zeros(1, token_count, token_count, dtype=torch.float32)
+    half = token_count // 2
+    mask[:, :half, half:] = -100.0
+    mask[:, half:, :half] = -100.0
+    return mask
+
+
+class WindowAttentionWrapper(nn.Module):
+    def __init__(self, module: nn.Module, with_mask: bool):
+        super().__init__()
+        self.module = module
+        self.with_mask = with_mask
+
+    def forward(self, x: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+        if self.with_mask:
+            if mask is None:
+                raise ValueError("mask is required when with_mask=True")
+            return self.module(x, mask=mask)
+        return self.module(x)
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts = args.artifacts
+    torch.manual_seed(args.seed)
+    parity_runner = SingleOutputParityRunner(ONNX_EXPORTER, ORT_SESSION_FACTORY, atol=args.atol, rtol=args.rtol)
+
+    print("=" * 60)
+    print("WindowAttention ONNX Parity Test")
+    print("=" * 60)
+    print(f"Config: {artifacts.config_path}")
+    print(f"Checkpoint: {artifacts.ckpt_path}")
+    print(f"ONNX: {artifacts.onnx_path}")
+
+    print("\n[1] Loading model...")
+    model = load_model(artifacts.config_path, artifacts.ckpt_path)
+
+    print("\n[2] Selecting WindowAttention module...")
+    module_name, module = find_window_attention(model, args.module_index)
+    module.eval()
+    print(f"  Module: {module_name}")
+
+    batch_windows, token_count, channel_count = derive_input_shape(module, args.batch_windows)
+    print(
+        "  Derived shape: "
+        f"windows={batch_windows}, tokens={token_count}, channels={channel_count}"
+    )
+    print(f"  Mask branch enabled: {args.with_mask}")
+
+    wrapper = WindowAttentionWrapper(module, with_mask=args.with_mask)
+    wrapper.eval()
+
+    export_x = torch.randn(batch_windows, token_count, channel_count, dtype=torch.float32)
+    export_inputs: tuple[torch.Tensor, ...]
+    if args.with_mask:
+        export_mask = build_mask(token_count)
+        export_inputs = (export_x, export_mask)
+    else:
+        export_inputs = (export_x,)
+
+    print("\n[3] Exporting to ONNX...")
+    onnx_path, session = parity_runner.export_and_create_session(
+        wrapper,
+        export_inputs,
+        artifacts.onnx_path,
+        input_names=[f"input_{index}" for index in range(len(export_inputs))],
+        output_names=["output"],
+        opset=args.opset,
+    )
+    print(f"  Exported: {onnx_path}")
+
+    print("\n[4] Creating ONNX Runtime session...")
+    print("  Session ready")
+
+    print("\n[5] Comparing PyTorch vs ONNX Runtime...")
+    summary = parity_runner.run_same_shape_suite(
+        wrapper,
+        session,
+        export_inputs,
+        num_samples=args.num_samples,
+        random_input_factory=lambda: (
+            (lambda x, mask: (x, mask) if args.with_mask else (x,))(
+                torch.randn(batch_windows, token_count, channel_count, dtype=torch.float32),
+                build_mask(token_count),
+            )
+        ),
+        captured_label="Export sample",
+        random_label="Sample",
+    )
+
+    print("\n[6] Summary")
+    print(f"  Samples tested: {args.num_samples}")
+    print(f"  Mismatches including export sample: {summary.mismatches}")
+    print(f"  Worst max abs diff: {summary.worst_max_abs_diff:.3e}")
+    print(f"  Worst mean abs diff: {summary.worst_mean_abs_diff:.3e}")
+    if summary.mismatches == 0:
+        print("  Result: WindowAttention exports correctly and matches ONNX Runtime within tolerance")
+    else:
+        print("  Result: WindowAttention exports, but ONNX Runtime output diverges from PyTorch")
+
+
+if __name__ == "__main__":
+    main()

--- a/export/export_to_onnx.py
+++ b/export/export_to_onnx.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from export.common import ArtifactResolver, ModelLoader, OnnxExporter, OnnxSessionFactory, VitOnnxExporter
+from export.debug_runner import SingleOutputParityRunner
+from export.export_workflow import ExportVerificationWorkflow, ExportWorkflowConfig
+
+
+ARTIFACT_RESOLVER = ArtifactResolver()
+MODEL_LOADER = ModelLoader()
+ONNX_EXPORTER = OnnxExporter()
+ORT_SESSION_FACTORY = OnnxSessionFactory()
+VIT_ONNX_EXPORTER = VitOnnxExporter()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export model.vit to ONNX using repo-local defaults.")
+    ARTIFACT_RESOLVER.add_common_arguments(parser)
+    parser.add_argument("--block-index", type=int, default=0)
+    parser.add_argument("--swin-module-index", type=int, default=0)
+    parser.add_argument("--window-attention-index", type=int, default=0)
+    parser.add_argument("--num-samples", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--context-frames", type=int, default=4)
+    parser.add_argument("--target-frames", type=int, default=1)
+    parser.add_argument("--opset", type=int, default=17)
+    parser.add_argument("--atol", type=float, default=1e-4)
+    parser.add_argument("--rtol", type=float, default=1e-4)
+    parser.add_argument("--disable-constant-folding", action="store_true")
+    args = parser.parse_args()
+    args.artifacts = ARTIFACT_RESOLVER.resolve_from_args(args)
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    workflow = ExportVerificationWorkflow(
+        config=ExportWorkflowConfig(
+            artifacts=args.artifacts,
+            block_index=args.block_index,
+            swin_module_index=args.swin_module_index,
+            window_attention_index=args.window_attention_index,
+            batch_size=args.batch_size,
+            context_frames=args.context_frames,
+            target_frames=args.target_frames,
+            num_samples=args.num_samples,
+            opset=args.opset,
+            atol=args.atol,
+            rtol=args.rtol,
+            do_constant_folding=not args.disable_constant_folding,
+        ),
+        model_loader=MODEL_LOADER,
+        parity_runner=SingleOutputParityRunner(
+            ONNX_EXPORTER,
+            ORT_SESSION_FACTORY,
+            atol=args.atol,
+            rtol=args.rtol,
+        ),
+        session_factory=ORT_SESSION_FACTORY,
+        vit_exporter=VIT_ONNX_EXPORTER,
+    )
+    raise SystemExit(workflow.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/export/export_workflow.py
+++ b/export/export_workflow.py
@@ -1,0 +1,518 @@
+# SPDX-License-Identifier: MIT
+# Author: Dr Shashank Pathak
+# Email: shashank@computer.org
+# Funding: German Research Project NXTAIM
+# See LICENSE for the full MIT license text.
+
+from __future__ import annotations
+
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import torch
+import torch.nn as nn
+
+from export.common import (
+    ModelLoader,
+    OnnxSessionFactory,
+    ResolvedArtifactPaths,
+    VitOnnxExporter,
+    VitOnnxWrapper,
+    make_vit_inputs,
+)
+from export.debug_runner import ParitySuiteSummary, SingleOutputParityRunner
+
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+GREEN = "\033[92m"
+RED = "\033[91m"
+YELLOW = "\033[93m"
+BLUE = "\033[94m"
+CYAN = "\033[96m"
+
+
+def style(text: str, *codes: str) -> str:
+    return "".join(codes) + text + RESET
+
+
+def status_badge(passed: bool) -> str:
+    return style(" PASS ", BOLD, GREEN) if passed else style(" FAIL ", BOLD, RED)
+
+
+def section_title(index: int, title: str) -> str:
+    return f"{style(f'[{index}]', BOLD, BLUE)} {style(title, BOLD)}"
+
+
+@dataclass(frozen=True)
+class ExportWorkflowConfig:
+    artifacts: ResolvedArtifactPaths
+    block_index: int
+    swin_module_index: int
+    window_attention_index: int
+    batch_size: int
+    context_frames: int
+    target_frames: int
+    num_samples: int
+    opset: int
+    atol: float
+    rtol: float
+    do_constant_folding: bool
+
+
+@dataclass(frozen=True)
+class OperationCheckResult:
+    name: str
+    passed: bool
+    mismatches: int
+    worst_max_abs_diff: float
+    worst_mean_abs_diff: float
+    details: str | None = None
+
+
+class ExportVerificationWorkflow:
+    def __init__(
+        self,
+        *,
+        config: ExportWorkflowConfig,
+        model_loader: ModelLoader,
+        parity_runner: SingleOutputParityRunner,
+        session_factory: OnnxSessionFactory,
+        vit_exporter: VitOnnxExporter,
+    ):
+        self.config = config
+        self.model_loader = model_loader
+        self.parity_runner = parity_runner
+        self.session_factory = session_factory
+        self.vit_exporter = vit_exporter
+        self.model: nn.Module | None = None
+
+    def run(self) -> int:
+        self._print_header()
+        self.model = self.model_loader.load(self.config.artifacts.config_path, self.config.artifacts.ckpt_path)
+
+        print(f"\n{section_title(2, 'Running preflight ONNX parity checks')}")
+        preflight_results = self._run_preflight_checks()
+        for result in preflight_results:
+            self._print_check_result(result)
+
+        if not all(result.passed for result in preflight_results):
+            print(f"\n{status_badge(False)} {style('Export aborted because at least one preflight check failed.', BOLD)}")
+            return 1
+
+        print(f"\n{section_title(3, 'Exporting model.vit to ONNX')}")
+        onnx_path = self.vit_exporter.export(
+            self._require_model(),
+            self.config.artifacts.onnx_path,
+            opset=self.config.opset,
+            do_constant_folding=self.config.do_constant_folding,
+        )
+        print(f"  {style('Artifact', DIM)} {onnx_path}")
+
+        print(f"\n{section_title(4, 'Checking exported model parity with graph optimizations disabled and enabled')}")
+        final_no_opt = self._check_exported_vit_parity(disable_optimizations=True)
+        final_opt = self._check_exported_vit_parity(disable_optimizations=False)
+        self._print_check_result(final_no_opt)
+        self._print_check_result(final_opt)
+
+        if not final_no_opt.passed:
+            print(f"\n{status_badge(False)} {style('Final exported model failed parity with graph optimizations disabled.', BOLD)}")
+            return 1
+
+        if not final_opt.passed:
+            print(
+                f"\n{style(' WARN ', BOLD, YELLOW)} "
+                f"{style('Export succeeded, but graph optimizations introduce mismatches. Use ORT graph optimizations disabled.', BOLD)}"
+            )
+        else:
+            print(
+                f"\n{status_badge(True)} "
+                f"{style('Export succeeded and final parity checks passed with graph optimizations both disabled and enabled.', BOLD)}"
+            )
+        return 0
+
+    def _print_header(self) -> None:
+        artifacts = self.config.artifacts
+        print(style("=" * 72, DIM))
+        print(style("Methodical ONNX Export Workflow", BOLD, CYAN))
+        print(style("=" * 72, DIM))
+        print(f"{style('Config     ', DIM)} {artifacts.config_path}")
+        print(f"{style('Checkpoint', DIM)} {artifacts.ckpt_path}")
+        print(f"{style('ONNX      ', DIM)} {artifacts.onnx_path}")
+        print(f"{style('Tolerance ', DIM)} atol={self.config.atol:.1e} rtol={self.config.rtol:.1e}")
+        print(f"\n{section_title(1, 'Loading model')}")
+
+    def _require_model(self) -> nn.Module:
+        if self.model is None:
+            raise RuntimeError("Model has not been loaded")
+        return self.model
+
+    def _print_check_result(self, result: OperationCheckResult) -> None:
+        print(
+            f"  {style(result.name, BOLD)} {status_badge(result.passed)} "
+            f"{style('mismatches', DIM)}={result.mismatches} "
+            f"{style('max', DIM)}={result.worst_max_abs_diff:.3e} "
+            f"{style('mean', DIM)}={result.worst_mean_abs_diff:.3e}"
+        )
+        if result.details:
+            print(f"    {style(result.details, DIM)}")
+
+    def _result_from_summary(self, name: str, summary: ParitySuiteSummary, details: str | None = None) -> OperationCheckResult:
+        return OperationCheckResult(
+            name=name,
+            passed=summary.mismatches == 0,
+            mismatches=summary.mismatches,
+            worst_max_abs_diff=summary.worst_max_abs_diff,
+            worst_mean_abs_diff=summary.worst_mean_abs_diff,
+            details=details,
+        )
+
+    def _run_preflight_checks(self) -> list[OperationCheckResult]:
+        mid_level_name, mid_level_check = self._select_mid_level_check()
+        print(f"  {style('Selected mid-level attention check', DIM)}: {style(mid_level_name, BOLD, CYAN)}")
+        return [
+            self._check_vit_wrapper(),
+            self._check_stdit_block(),
+            mid_level_check(),
+            self._check_window_attention(),
+        ]
+
+    def _temporary_onnx_path(self) -> Path:
+        handle = tempfile.NamedTemporaryFile(suffix=".onnx", delete=False)
+        handle.close()
+        return Path(handle.name)
+
+    def _run_temp_suite(
+        self,
+        name: str,
+        module: nn.Module,
+        sample_inputs: tuple[torch.Tensor, ...],
+        *,
+        random_input_factory: Callable[[], tuple[torch.Tensor, ...]],
+        input_names: list[str],
+        details: str | None = None,
+    ) -> OperationCheckResult:
+        temp_onnx_path = self._temporary_onnx_path()
+        try:
+            _, session = self.parity_runner.export_and_create_session(
+                module,
+                sample_inputs,
+                temp_onnx_path,
+                input_names=input_names,
+                output_names=["output"],
+                opset=self.config.opset,
+                do_constant_folding=self.config.do_constant_folding,
+                disable_optimizations=True,
+            )
+            summary = self.parity_runner.run_same_shape_suite(
+                module,
+                session,
+                sample_inputs,
+                num_samples=self.config.num_samples,
+                random_input_factory=random_input_factory,
+            )
+            return self._result_from_summary(name, summary, details)
+        except Exception as exc:
+            return OperationCheckResult(
+                name=name,
+                passed=False,
+                mismatches=1,
+                worst_max_abs_diff=float("inf"),
+                worst_mean_abs_diff=float("inf"),
+                details=str(exc),
+            )
+        finally:
+            if temp_onnx_path.exists():
+                os.remove(temp_onnx_path)
+
+    def _check_vit_wrapper(self) -> OperationCheckResult:
+        model = self._require_model()
+        wrapper = VitOnnxWrapper(model.vit).eval()
+        sample_inputs = make_vit_inputs(
+            model.vit,
+            batch_size=self.config.batch_size,
+            context_frames=self.config.context_frames,
+            target_frames=self.config.target_frames,
+        )
+        return self._run_temp_suite(
+            "model.vit preflight",
+            wrapper,
+            sample_inputs,
+            random_input_factory=lambda: make_vit_inputs(
+                model.vit,
+                batch_size=self.config.batch_size,
+                context_frames=self.config.context_frames,
+                target_frames=self.config.target_frames,
+            ),
+            input_names=["input_0", "input_1", "input_2", "input_3"],
+        )
+
+    def _capture_block_io(self) -> tuple[nn.Module, torch.Tensor, torch.Tensor]:
+        model = self._require_model()
+        vit_inputs = make_vit_inputs(
+            model.vit,
+            batch_size=self.config.batch_size,
+            context_frames=self.config.context_frames,
+            target_frames=self.config.target_frames,
+        )
+        blocks = getattr(model.vit, "blocks", None)
+        if blocks is None:
+            raise ValueError("model.vit does not expose blocks")
+        if self.config.block_index < 0 or self.config.block_index >= len(blocks):
+            raise IndexError(f"block_index must be in [0, {len(blocks) - 1}]")
+
+        block = blocks[self.config.block_index]
+        captured: dict[str, torch.Tensor] = {}
+
+        def hook(_module: nn.Module, inputs: tuple[torch.Tensor, ...], _output: torch.Tensor) -> None:
+            captured["x"] = inputs[0].detach().cpu().clone()
+            captured["c"] = inputs[1].detach().cpu().clone()
+
+        handle = block.register_forward_hook(hook)
+        try:
+            with torch.no_grad():
+                target_t, context, t, frame_rate = vit_inputs
+                model.vit(target_t, context, t, frame_rate=frame_rate)
+        finally:
+            handle.remove()
+
+        if "x" not in captured or "c" not in captured:
+            raise RuntimeError("Failed to capture block inputs from model.vit forward")
+        return block, captured["x"], captured["c"]
+
+    def _check_stdit_block(self) -> OperationCheckResult:
+        try:
+            block, captured_x, captured_c = self._capture_block_io()
+        except Exception as exc:
+            return OperationCheckResult(
+                name="STDiT block preflight",
+                passed=False,
+                mismatches=1,
+                worst_max_abs_diff=float("inf"),
+                worst_mean_abs_diff=float("inf"),
+                details=str(exc),
+            )
+
+        return self._run_temp_suite(
+            "STDiT block preflight",
+            block.eval(),
+            (captured_x, captured_c),
+            random_input_factory=lambda: (
+                torch.randn_like(captured_x),
+                torch.randn_like(captured_c),
+            ),
+            input_names=["input_0", "input_1"],
+            details=f"block_index={self.config.block_index}",
+        )
+
+    def _find_named_module(self, class_name: str, module_index: int) -> tuple[str, nn.Module]:
+        model = self._require_model()
+        matches: list[tuple[str, nn.Module]] = []
+        for name, module in model.vit.named_modules():
+            if type(module).__name__ == class_name:
+                matches.append((name, module))
+
+        if not matches:
+            raise RuntimeError(f"No {class_name} modules found")
+        if module_index < 0 or module_index >= len(matches):
+            raise IndexError(f"{class_name} module index must be in [0, {len(matches) - 1}]")
+        return matches[module_index]
+
+    def _first_param(self, module: nn.Module) -> torch.nn.Parameter:
+        return next(module.parameters())
+
+    def _make_like(self, module: nn.Module, *shape: int) -> torch.Tensor:
+        param = self._first_param(module)
+        return torch.randn(*shape, device=param.device, dtype=param.dtype)
+
+    def _derive_swin_block_input(self, module: nn.Module, batch_size: int = 2) -> tuple[torch.Tensor, tuple[int, int], int]:
+        input_resolution = getattr(module, "input_resolution", None)
+        if input_resolution is None:
+            raise ValueError("SwinTransformerBlock does not expose input_resolution")
+        channel_count = getattr(module, "dim", None)
+        if channel_count is None:
+            raise ValueError("SwinTransformerBlock does not expose dim")
+        token_count = int(input_resolution[0] * input_resolution[1])
+        x = self._make_like(module, batch_size, token_count, channel_count)
+        return x, tuple(input_resolution), channel_count
+
+    def _check_swin_block(self) -> OperationCheckResult:
+        try:
+            module_name, block = self._find_named_module("SwinTransformerBlock", self.config.swin_module_index)
+            sample_x, input_resolution, channel_count = self._derive_swin_block_input(block, batch_size=max(1, self.config.batch_size))
+            return self._run_temp_suite(
+                "SwinTransformerBlock preflight",
+                block.eval(),
+                (sample_x,),
+                random_input_factory=lambda: (
+                    torch.randn_like(sample_x),
+                ),
+                input_names=["input_0"],
+                details=(
+                    f"module={module_name} resolution={input_resolution} channels={channel_count}"
+                ),
+            )
+        except Exception as exc:
+            return OperationCheckResult(
+                name="SwinTransformerBlock preflight",
+                passed=False,
+                mismatches=1,
+                worst_max_abs_diff=float("inf"),
+                worst_mean_abs_diff=float("inf"),
+                details=str(exc),
+            )
+
+    def _check_swin_attention(self) -> OperationCheckResult:
+        try:
+            module_name, attn = self._find_named_module("SwinAttention", self.config.swin_module_index)
+            sample_x, input_resolution, channel_count = self._derive_swin_block_input(attn, batch_size=max(1, self.config.batch_size))
+            return self._run_temp_suite(
+                "SwinAttention preflight",
+                attn.eval(),
+                (sample_x,),
+                random_input_factory=lambda: (
+                    torch.randn_like(sample_x),
+                ),
+                input_names=["input_0"],
+                details=(
+                    f"module={module_name} resolution={input_resolution} channels={channel_count}"
+                ),
+            )
+        except Exception as exc:
+            return OperationCheckResult(
+                name="SwinAttention preflight",
+                passed=False,
+                mismatches=1,
+                worst_max_abs_diff=float("inf"),
+                worst_mean_abs_diff=float("inf"),
+                details=str(exc),
+            )
+
+    def _select_mid_level_check(self) -> tuple[str, Callable[[], OperationCheckResult]]:
+        model = self._require_model()
+        class_names = {type(module).__name__ for _, module in model.vit.named_modules()}
+        if "SwinTransformerBlock" in class_names:
+            return "SwinTransformerBlock", self._check_swin_block
+        if "SwinAttention" in class_names:
+            return "SwinAttention", self._check_swin_attention
+        return "skipped", self._skip_mid_level_attention_check
+
+    def _skip_mid_level_attention_check(self) -> OperationCheckResult:
+        return OperationCheckResult(
+            name="mid-level attention preflight",
+            passed=True,
+            mismatches=0,
+            worst_max_abs_diff=0.0,
+            worst_mean_abs_diff=0.0,
+            details="No SwinTransformerBlock or SwinAttention modules found; skipped.",
+        )
+
+    def _derive_window_attention_input(self, module: nn.Module, batch_windows: int = 2) -> tuple[torch.Tensor, int, int]:
+        window_size = getattr(module, "window_size", None)
+        if window_size is None:
+            raise ValueError("WindowAttention module does not expose window_size")
+        if isinstance(window_size, int):
+            token_count = window_size * window_size
+        else:
+            token_count = int(window_size[0] * window_size[1])
+        channel_count = getattr(module, "dim", None)
+        if channel_count is None and hasattr(module, "qkv"):
+            channel_count = module.qkv.in_features
+        if channel_count is None:
+            raise ValueError("WindowAttention module does not expose an input channel size")
+        x = self._make_like(module, batch_windows, token_count, channel_count)
+        return x, token_count, channel_count
+
+    def _check_window_attention(self) -> OperationCheckResult:
+        try:
+            module_name, attn = self._find_named_module("WindowAttention", self.config.window_attention_index)
+            sample_x, token_count, channel_count = self._derive_window_attention_input(attn)
+            return self._run_temp_suite(
+                "WindowAttention preflight",
+                attn.eval(),
+                (sample_x,),
+                random_input_factory=lambda: (
+                    torch.randn_like(sample_x),
+                ),
+                input_names=["input_0"],
+                details=f"module={module_name} tokens={token_count} channels={channel_count}",
+            )
+        except Exception as exc:
+            return OperationCheckResult(
+                name="WindowAttention preflight",
+                passed=False,
+                mismatches=1,
+                worst_max_abs_diff=float("inf"),
+                worst_mean_abs_diff=float("inf"),
+                details=str(exc),
+            )
+
+    def _build_named_vit_ort_inputs(
+        self,
+        target_t: torch.Tensor,
+        context: torch.Tensor,
+        t: torch.Tensor,
+        frame_rate: torch.Tensor,
+    ) -> dict[str, object]:
+        return {
+            "target_t": target_t.cpu().numpy(),
+            "context": context.cpu().numpy(),
+            "t": t.cpu().numpy(),
+            "frame_rate": frame_rate.cpu().numpy(),
+        }
+
+    def _check_exported_vit_parity(self, *, disable_optimizations: bool) -> OperationCheckResult:
+        model = self._require_model()
+        wrapper = VitOnnxWrapper(model.vit).eval()
+        session = self.session_factory.create_cpu_session(
+            self.config.artifacts.onnx_path,
+            disable_optimizations=disable_optimizations,
+        )
+
+        captured_inputs = make_vit_inputs(
+            model.vit,
+            batch_size=self.config.batch_size,
+            context_frames=self.config.context_frames,
+            target_frames=self.config.target_frames,
+        )
+        captured_result = self.parity_runner.compare_sample(
+            wrapper,
+            session,
+            captured_inputs,
+            ort_inputs=self._build_named_vit_ort_inputs(*captured_inputs),
+        )
+
+        worst_max_abs_diff = captured_result.max_abs_diff
+        worst_mean_abs_diff = captured_result.mean_abs_diff
+        mismatches = 0 if captured_result.ok else 1
+
+        for _ in range(self.config.num_samples):
+            sample_inputs = make_vit_inputs(
+                model.vit,
+                batch_size=self.config.batch_size,
+                context_frames=self.config.context_frames,
+                target_frames=self.config.target_frames,
+            )
+            sample_result = self.parity_runner.compare_sample(
+                wrapper,
+                session,
+                sample_inputs,
+                ort_inputs=self._build_named_vit_ort_inputs(*sample_inputs),
+            )
+            if not sample_result.ok:
+                mismatches += 1
+            worst_max_abs_diff = max(worst_max_abs_diff, sample_result.max_abs_diff)
+            worst_mean_abs_diff = max(worst_mean_abs_diff, sample_result.mean_abs_diff)
+
+        mode_label = "disabled" if disable_optimizations else "enabled"
+        return OperationCheckResult(
+            name=f"final model parity (graph optimizations {mode_label})",
+            passed=mismatches == 0,
+            mismatches=mismatches,
+            worst_max_abs_diff=worst_max_abs_diff,
+            worst_mean_abs_diff=worst_mean_abs_diff,
+        )


### PR DESCRIPTION
This supports verification of various elements of Orbis operator, layers and modules wrt Onnx export. Typically it needs to be done only once per network architecture however we provide it as a package so that it can be used beyond Orbis v1.0, including other networks altogether. This a part of work done under NXTAIM (2024-2026).